### PR TITLE
Alter recent posts and main body content to only show 'post' types of…

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -6,7 +6,7 @@
 			<h1 class="page-title">{{ .Title }}</h1>
 		</header>
 		{{ end }}
-		{{ $paginator := .Paginate .Data.Pages }}
+		{{ $paginator := .Paginate ( where .Data.Pages "Section" "post") }}
 		{{ range $paginator.Pages }}
 		<article class="mr-loop-item post type-post hentry clearfix">
 			{{ if .Params.thumbnail }}

--- a/layouts/partials/widgets/recent.html
+++ b/layouts/partials/widgets/recent.html
@@ -2,7 +2,7 @@
 <div class="mr-widget widget_recent_entries">
 	<h4 class="mr-widget-title"><span class="mr-widget-title-inner">Recent Posts</span></h4>
 	<ul>
-		{{ range first 10 .Site.Pages }}
+		{{ range first 10 (where .Site.Pages "Section" "post") }}
 		<li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
 		{{ end }}
 	</ul>


### PR DESCRIPTION
… content. Allows other types of content to be shown/organized differently than posts