### PR TITLE
Navigation contain tags or categories.

### DIFF
--- a/layouts/partials/post_nav.html
+++ b/layouts/partials/post_nav.html
@@ -1,14 +1,14 @@
 {{- if .Site.Params.post_navigation }}
-{{- if or (.Prev) (.Next) }}
+{{- if or (.PrevInSection) (.NextInSection) }}
 <nav class="post-nav row clearfix" itemscope="itemscope" itemtype="http://schema.org/SiteNavigationElement">
-	{{- if .Prev }}
+	{{- if .PrevInSection }}
 	<div class="post-nav__item post-nav__item--prev col-1-2">
-		<a class="post-nav__link" href="{{.Prev.Permalink}}" rel="prev"><span class="post-nav__caption">«Previous</span><p class="post-nav__post-title">{{.Prev.Title}}</p></a>
+		<a class="post-nav__link" href="{{.PrevInSection.Permalink}}" rel="prev"><span class="post-nav__caption">«Previous</span><p class="post-nav__post-title">{{.PrevInSection.Title}}</p></a>
 	</div>
 	{{- end }}
-	{{- if .Next }}
+	{{- if .NextInSection }}
 	<div class="post-nav__item post-nav__item--next col-1-2">
-		<a class="post-nav__link" href="{{.Next.Permalink}}" rel="next"><span class="post-nav__caption">Next»</span><p class="post-nav__post-title">{{.Next.Title}}</p></a>
+		<a class="post-nav__link" href="{{.NextInSection.Permalink}}" rel="next"><span class="post-nav__caption">Next»</span><p class="post-nav__post-title">{{.NextInSection.Title}}</p></a>
 	</div>
 	{{- end }}
 </nav>


### PR DESCRIPTION
navigation contains tags page or categories page.

so when i navigate posts, stopped in tags page.

i think these theme using just one section names "post".

So I think that only posts should come out to navigation. 😃 