### PR TITLE
Use domain relative urls

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -17,7 +17,7 @@
 		<div class="post__content clearfix">
 			{{- if .Params.thumbnail }}
 			<figure class="post__thumbnail">
-				<img src="{{ .Params.thumbnail | absURL }}" alt="{{ .Title }}">
+				<img src="{{ .Params.thumbnail | relURL }}" alt="{{ .Title }}">
 			</figure>
 			{{- end }}
 			{{ .Content }}

--- a/layouts/partials/authorbox.html
+++ b/layouts/partials/authorbox.html
@@ -5,7 +5,7 @@
 	{{- end }}
 	{{- with .Site.Author.avatar }}
 	<figure class="authorbox__avatar">
-		<img alt="{{ $.Site.Author.name }} avatar" src="{{ $.Site.Author.avatar | absURL }}" class="avatar" height="90" width="90">
+		<img alt="{{ $.Site.Author.name }} avatar" src="{{ $.Site.Author.avatar | relURL }}" class="avatar" height="90" width="90">
 	</figure>
 	{{- end }}
 	{{- with .Site.Author.name }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -10,16 +10,16 @@
 <link rel="dns-prefetch" href="//fonts.googleapis.com" />
 {{ if .RSSLink }}<link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }} Feed" href="{{ .RSSLink }}">{{ end }}
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,400italic,700" type="text/css" media="all" />
-<link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css" type="text/css" media="all" />
-<script type="text/javascript" src="{{ .Site.BaseURL }}js/scripts.js"></script>
-<link rel="shortcut icon" href="{{ .Site.BaseURL }}favicon.ico">
+<link rel="stylesheet" href="{{ "/css/style.css" | relURL }}" type="text/css" media="all" />
+<script type="text/javascript" src="{{ "/js/scripts.js" | relURL }}"></script>
+<link rel="shortcut icon" href="{{ "/favicon.ico" | relURL }}">
 </head>
 <body class="body {{ if (.Site.Params.leftsidebar) or (.Params.leftsidebar) }}body-left-sidebar{{ else }}body-right-sidebar{{ end }} mobile" itemscope="itemscope" itemtype="http://schema.org/WebPage">
 	<div class="container container-outer">
 		<header class="header" itemscope="itemscope" itemtype="http://schema.org/WPHeader">
 			<div class="container container-inner clearfix">
 				<div class="logo" role="banner" itemscope="itemscope" itemtype="http://schema.org/Brand">
-					<a class="logo__link" href="{{ .Site.BaseURL }}" title="{{ .Site.Title }}" rel="home">
+					<a class="logo__link" href="{{ "/" | relLangURL }}" title="{{ .Site.Title }}" rel="home">
 						<h1 class="logo__title">{{ .Site.Title }}</h1>
 						{{ with .Site.Params.subtitle }}<h2 class="logo__tagline">{{ . }}</h2>{{ end }}
 					</a>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -10,16 +10,16 @@
 <link rel="dns-prefetch" href="//fonts.googleapis.com" />
 {{ if .RSSLink }}<link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }} Feed" href="{{ .RSSLink }}">{{ end }}
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,400italic,700" type="text/css" media="all" />
-<link rel="stylesheet" href="{{ "/css/style.css" | relURL }}" type="text/css" media="all" />
-<script type="text/javascript" src="{{ "/js/scripts.js" | relURL }}"></script>
-<link rel="shortcut icon" href="{{ "/favicon.ico" | relURL }}">
+<link rel="stylesheet" href="{{ "css/style.css" | relURL }}" type="text/css" media="all" />
+<script type="text/javascript" src="{{ "js/scripts.js" | relURL }}"></script>
+<link rel="shortcut icon" href="{{ "favicon.ico" | relURL }}">
 </head>
 <body class="body {{ if (.Site.Params.leftsidebar) or (.Params.leftsidebar) }}body-left-sidebar{{ else }}body-right-sidebar{{ end }} mobile" itemscope="itemscope" itemtype="http://schema.org/WebPage">
 	<div class="container container-outer">
 		<header class="header" itemscope="itemscope" itemtype="http://schema.org/WPHeader">
 			<div class="container container-inner clearfix">
 				<div class="logo" role="banner" itemscope="itemscope" itemtype="http://schema.org/Brand">
-					<a class="logo__link" href="{{ "/" | relLangURL }}" title="{{ .Site.Title }}" rel="home">
+					<a class="logo__link" href="{{ "" | relLangURL }}" title="{{ .Site.Title }}" rel="home">
 						<h1 class="logo__title">{{ .Site.Title }}</h1>
 						{{ with .Site.Params.subtitle }}<h2 class="logo__tagline">{{ . }}</h2>{{ end }}
 					</a>

--- a/layouts/partials/list_item.html
+++ b/layouts/partials/list_item.html
@@ -2,14 +2,14 @@
 	{{- if .Params.thumbnail }}
 	<figure class="list__thumbnail">
 		<a href="{{ .Permalink }}">
-			<img src="{{ .Params.thumbnail | absURL }}" alt="{{ .Title }}" />
+			<img src="{{ .Params.thumbnail | relURL }}" alt="{{ .Title }}" />
 		</a>
 	</figure>
 	{{- end }}
 	<div class="list__content clearfix">
 		<header class="list__header">
 			<h3 class="list__title post__title ">
-				<a href="{{ .Permalink }}" rel="bookmark">{{ .Title }}</a>
+				<a href="{{ .RelPermalink }}" rel="bookmark">{{ .Title }}</a>
 			</h3>
 			<div class="list__meta meta">
 				<svg class="icon icon-time" height="14" viewBox="0 0 16 16" width="14" xmlns="http://www.w3.org/2000/svg"><path d="m8-.0000003c-4.4 0-8 3.6-8 8 0 4.4000003 3.6 8.0000003 8 8.0000003 4.4 0 8-3.6 8-8.0000003 0-4.4-3.6-8-8-8zm0 14.4000003c-3.52 0-6.4-2.88-6.4-6.4000003 0-3.52 2.88-6.4 6.4-6.4 3.52 0 6.4 2.88 6.4 6.4 0 3.5200003-2.88 6.4000003-6.4 6.4000003zm.4-10.4000003h-1.2v4.8l4.16 2.5600003.64-1.04-3.6-2.1600003z"/></svg>

--- a/layouts/partials/post_nav.html
+++ b/layouts/partials/post_nav.html
@@ -3,12 +3,12 @@
 <nav class="post-nav row clearfix" itemscope="itemscope" itemtype="http://schema.org/SiteNavigationElement">
 	{{- if .PrevInSection }}
 	<div class="post-nav__item post-nav__item--prev col-1-2">
-		<a class="post-nav__link" href="{{.PrevInSection.Permalink}}" rel="prev"><span class="post-nav__caption">«Previous</span><p class="post-nav__post-title">{{.PrevInSection.Title}}</p></a>
+		<a class="post-nav__link" href="{{.PrevInSection.RelPermalink}}" rel="prev"><span class="post-nav__caption">«Previous</span><p class="post-nav__post-title">{{.PrevInSection.Title}}</p></a>
 	</div>
 	{{- end }}
 	{{- if .NextInSection }}
 	<div class="post-nav__item post-nav__item--next col-1-2">
-		<a class="post-nav__link" href="{{.NextInSection.Permalink}}" rel="next"><span class="post-nav__caption">Next»</span><p class="post-nav__post-title">{{.NextInSection.Title}}</p></a>
+		<a class="post-nav__link" href="{{.NextInSection.RelPermalink}}" rel="next"><span class="post-nav__caption">Next»</span><p class="post-nav__post-title">{{.NextInSection.Title}}</p></a>
 	</div>
 	{{- end }}
 </nav>

--- a/layouts/partials/widgets/categories.html
+++ b/layouts/partials/widgets/categories.html
@@ -6,7 +6,7 @@
 	<div class="widget__content">
 		<ul class="widget__list">
 			{{- range $name, $items := .Site.Taxonomies.categories }}
-			<li class="widget__item"><a class="widget__link" href="{{ "/categories/" | relLangURL }}{{ $name | urlize | lower }}">{{ $name | title }}</a></li>
+			<li class="widget__item"><a class="widget__link" href="{{ "categories/" | relLangURL }}{{ $name | urlize | lower }}">{{ $name | title }}</a></li>
 			{{- end }}
 		</ul>
 	</div>

--- a/layouts/partials/widgets/categories.html
+++ b/layouts/partials/widgets/categories.html
@@ -6,7 +6,7 @@
 	<div class="widget__content">
 		<ul class="widget__list">
 			{{- range $name, $items := .Site.Taxonomies.categories }}
-			<li class="widget__item"><a class="widget__link" href="{{ $.Site.BaseURL }}categories/{{ $name | urlize | lower }}">{{ $name | title }}</a></li>
+			<li class="widget__item"><a class="widget__link" href="{{ "/categories/" | relLangURL }}{{ $name | urlize | lower }}">{{ $name | title }}</a></li>
 			{{- end }}
 		</ul>
 	</div>

--- a/layouts/partials/widgets/taglist.html
+++ b/layouts/partials/widgets/taglist.html
@@ -5,7 +5,7 @@
 	<h4 class="widget__title">Tags</h4>
 	<div class="widget__content">
 		{{- range $name, $items := .Site.Taxonomies.tags }}
-		<a class="widget__link widget__link--taglist" href="{{ $.Site.BaseURL }}tags/{{ $name | urlize | lower }}" title="{{ $name }}">{{ $name }}{{ if $.Site.Params.widgets.tags_counter }} ({{ $items.Count }}){{ end }}</a>
+		<a class="widget__link widget__link--taglist" href="{{ "/tags/" | relLangURL }}{{ $name | urlize | lower }}" title="{{ $name }}">{{ $name }}{{ if $.Site.Params.widgets.tags_counter }} ({{ $items.Count }}){{ end }}</a>
 		{{- end }}
 	</div>
 </div>

--- a/layouts/partials/widgets/taglist.html
+++ b/layouts/partials/widgets/taglist.html
@@ -5,7 +5,7 @@
 	<h4 class="widget__title">Tags</h4>
 	<div class="widget__content">
 		{{- range $name, $items := .Site.Taxonomies.tags }}
-		<a class="widget__link widget__link--taglist" href="{{ "/tags/" | relLangURL }}{{ $name | urlize | lower }}" title="{{ $name }}">{{ $name }}{{ if $.Site.Params.widgets.tags_counter }} ({{ $items.Count }}){{ end }}</a>
+		<a class="widget__link widget__link--taglist" href="{{ "tags/" | relLangURL }}{{ $name | urlize | lower }}" title="{{ $name }}">{{ $name }}{{ if $.Site.Params.widgets.tags_counter }} ({{ $items.Count }}){{ end }}</a>
 		{{- end }}
 	</div>
 </div>


### PR DESCRIPTION
Less verbose html pages from it, and ability to test on a different domain. In addition the `relativeURLs` site config will allow it to work just from the file-system.

The only remaining absolute urls are either meant to be (as is for RSS feeds for syndication), or the html RSSLink. The latter there is no obvious way to make relative.