### PR TITLE
Add ability to define which sections are considered post sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
     leftsidebar = false # Move sidebar to the left side if true
     authorbox = true
     post_navigation = true
-    postSections = ["post"]
+    postSections = ["post"] # the section pages to show on home page and the "Recent articles" widget
+    #postSections = ["blog", "news"] # alternative that shows more than one section's pages
 
 
 [Params.widgets]

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
     leftsidebar = false # Move sidebar to the left side if true
     authorbox = true
     post_navigation = true
+    postSections = ["post"]
 
 
 [Params.widgets]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -20,6 +20,7 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
     leftsidebar = false # Move sidebar to the left side if true
     authorbox = true
     post_navigation = true
+    postSections = ["post"]
 
 
 [Params.widgets]

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,7 +13,7 @@
 		</div>
 
 		{{- if .IsHome }}
-			{{- $paginator := .Paginate (where .Data.Pages "Section" "post") }}
+			{{- $paginator := .Paginate ( where .Data.Pages "Section" "in" ($.Param "postSections" | default (slice "post")) ) }}
 			{{- range $paginator.Pages }}
 				{{ partial "list_item.html" . }}
 			{{- end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,7 +13,8 @@
 		</div>
 
 		{{- if .IsHome }}
-			{{- $paginator := .Paginate ( where .Data.Pages "Section" "in" ($.Param "postSections" | default (slice "post")) ) }}
+			{{- $postSections := ($.Param "postSections" | default (slice "post")) }}
+			{{- $paginator := .Paginate ( where .Data.Pages "Section" "in" $postSections ) }}
 			{{- range $paginator.Pages }}
 				{{ partial "list_item.html" . }}
 			{{- end }}
@@ -21,7 +22,7 @@
 			<div class="warning">
 				<svg class="warning__icon icon icon-files" viewBox="0 0 384 384" width="96" height="96" xmlns="http://www.w3.org/2000/svg" fill="#ddd"><path d="m368 64h-224-16v16 288 16h16 224 16v-16-288-16zm-16 288h-192v-256h192zm-320-320h192v16h32v-32-16h-16-224-16v16 288 16h16 96v-32h-80zm144 272h160v-32h-160zm0-64h160v-32h-160zm0-64h160v-32h-160zm-128 64h64v-32h-64zm0-64h64v-32h-64zm0-64h64v-32h-64z"/></svg>
 				<h3 class="warning__headline">You don't have any posts yet!</h3>
-				<p class="warning__text">As posts are added in content/post folder, they'll appear here.</p>
+				<p class="warning__text">As posts are added in {{ replaceRE ",([^,]*)$" " and $1" (delimit (apply $postSections "printf" "content/%s" ".") ", ") }} folder{{ if gt (len $postSections) 1 }}s{{ end }}, they'll appear here.</p>
 			</div>
 		{{- end }}
 		{{ else }}

--- a/layouts/partials/widgets/recent.html
+++ b/layouts/partials/widgets/recent.html
@@ -4,7 +4,7 @@
 	<div class="widget__content">
 		<ul class="widget__list">
 			{{- $recent_articles_num := (.Site.Params.widgets.recent_articles_num | default 10) }}
-			{{- range first $recent_articles_num (where .Site.RegularPages "Section" "post") }}
+			{{- range first $recent_articles_num (where .Site.RegularPages "Section" "in" (.Site.Params.postSections | default (slice "post"))) }}
 			<li class="widget__item"><a class="widget__link" href="{{ .RelPermalink }}">{{ .Title }}</a></li>
 			{{- end }}
 		</ul>


### PR DESCRIPTION
I prefer "blog" to "post" for urls, and this helped me to migrate from Wordpress without messing with permalink urls.

Also this will allow someone to include multiple sections if wanted.