### PR TITLE
Only add post meta if any exists

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,15 +4,19 @@
 	<article class="post">
 		<header class="post__header clearfix">
 			<h1 class="post__title">{{ .Title }}</h1>
+			{{- if or (not .Date.IsZero) .Params.categories }}
 			<p class="post__meta meta">
+				{{- if not .Date.IsZero }}
 				<svg class="icon icon-time" height="14" viewBox="0 0 16 16" width="14" xmlns="http://www.w3.org/2000/svg"><path d="m8-.0000003c-4.4 0-8 3.6-8 8 0 4.4000003 3.6 8.0000003 8 8.0000003 4.4 0 8-3.6 8-8.0000003 0-4.4-3.6-8-8-8zm0 14.4000003c-3.52 0-6.4-2.88-6.4-6.4000003 0-3.52 2.88-6.4 6.4-6.4 3.52 0 6.4 2.88 6.4 6.4 0 3.5200003-2.88 6.4000003-6.4 6.4000003zm.4-10.4000003h-1.2v4.8l4.16 2.5600003.64-1.04-3.6-2.1600003z"/></svg>
 				<time class="post__meta-date" datetime="{{ .Date.Format "2006-01-02T15:04:05" }}">{{.Date.Format "January 02, 2006"}}</time>
+				{{- end }}
 				{{- if .Params.categories }}
 				<span class="post__meta-categories meta-categories">
 					<svg class="icon icon-category" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m7 2l1 2h8v11h-16v-13z"/></svg>
 					{{ range $index, $category := .Params.categories }}{{ if gt $index 0 }}, {{ end }}<a class="meta-categories__link" href="{{ "/categories/" | relLangURL }}{{ . | urlize | lower }}" rel="category">{{ . }}</a>{{ end }}</span>
 				{{- end }}
 			</p>
+			{{- end }}
 		</header>
 		<div class="post__content clearfix">
 			{{- if .Params.thumbnail }}

--- a/layouts/partials/list_item.html
+++ b/layouts/partials/list_item.html
@@ -11,10 +11,12 @@
 			<h3 class="list__title post__title ">
 				<a href="{{ .Permalink }}" rel="bookmark">{{ .Title }}</a>
 			</h3>
+			{{- if not .Date.IsZero }}
 			<div class="list__meta meta">
 				<svg class="icon icon-time" height="14" viewBox="0 0 16 16" width="14" xmlns="http://www.w3.org/2000/svg"><path d="m8-.0000003c-4.4 0-8 3.6-8 8 0 4.4000003 3.6 8.0000003 8 8.0000003 4.4 0 8-3.6 8-8.0000003 0-4.4-3.6-8-8-8zm0 14.4000003c-3.52 0-6.4-2.88-6.4-6.4000003 0-3.52 2.88-6.4 6.4-6.4 3.52 0 6.4 2.88 6.4 6.4 0 3.5200003-2.88 6.4000003-6.4 6.4000003zm.4-10.4000003h-1.2v4.8l4.16 2.5600003.64-1.04-3.6-2.1600003z"/></svg>
 				<time class="list__meta-date" datetime="{{ .Date.Format "2006-01-02T15:04:05" }}">{{.Date.Format "January 02, 2006"}}</time>
 			</div>
+			{{- end }}
 		</header>
 		<div class="list__excerpt">
 			{{ .Summary }}


### PR DESCRIPTION
A missing page date renders a bad date, so hide the date if it's not set.

A page with no date and no categories renders badly, so remove the meta container if neither are defined.