### PR TITLE
Support for lastmod in frontmatter.

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -9,6 +9,9 @@
 				{{- if not .Date.IsZero }}
 				<svg class="icon icon-time" height="14" viewBox="0 0 16 16" width="14" xmlns="http://www.w3.org/2000/svg"><path d="m8-.0000003c-4.4 0-8 3.6-8 8 0 4.4000003 3.6 8.0000003 8 8.0000003 4.4 0 8-3.6 8-8.0000003 0-4.4-3.6-8-8-8zm0 14.4000003c-3.52 0-6.4-2.88-6.4-6.4000003 0-3.52 2.88-6.4 6.4-6.4 3.52 0 6.4 2.88 6.4 6.4 0 3.5200003-2.88 6.4000003-6.4 6.4000003zm.4-10.4000003h-1.2v4.8l4.16 2.5600003.64-1.04-3.6-2.1600003z"/></svg>
 				<time class="post__meta-date" datetime="{{ .Date.Format "2006-01-02T15:04:05" }}">{{.Date.Format "January 02, 2006"}}</time>
+				{{- if ne .Date .Lastmod }}
+					<time class="post__meta-lastmod" datetime="{{ .Lastmod.Format "2006-01-02T15:04:05" }}"> (Last Modified: {{.Lastmod.Format "January 02, 2006"}})</time>
+				{{- end }}
 				{{- end }}
 				{{- if .Params.categories }}
 				<span class="post__meta-categories meta-categories">

--- a/layouts/partials/list_item.html
+++ b/layouts/partials/list_item.html
@@ -15,6 +15,9 @@
 			<div class="list__meta meta">
 				<svg class="icon icon-time" height="14" viewBox="0 0 16 16" width="14" xmlns="http://www.w3.org/2000/svg"><path d="m8-.0000003c-4.4 0-8 3.6-8 8 0 4.4000003 3.6 8.0000003 8 8.0000003 4.4 0 8-3.6 8-8.0000003 0-4.4-3.6-8-8-8zm0 14.4000003c-3.52 0-6.4-2.88-6.4-6.4000003 0-3.52 2.88-6.4 6.4-6.4 3.52 0 6.4 2.88 6.4 6.4 0 3.5200003-2.88 6.4000003-6.4 6.4000003zm.4-10.4000003h-1.2v4.8l4.16 2.5600003.64-1.04-3.6-2.1600003z"/></svg>
 				<time class="list__meta-date" datetime="{{ .Date.Format "2006-01-02T15:04:05" }}">{{.Date.Format "January 02, 2006"}}</time>
+				{{- if ne .Date .Lastmod }}
+					<time class="list__meta-lastmod" datetime="{{ .Lastmod.Format "2006-01-02T15:04:05" }}"> (Last Modified: {{.Lastmod.Format "January 02, 2006"}})</time>
+				{{- end }}
 			</div>
 			{{- end }}
 		</header>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -558,7 +558,7 @@ select {
 	vertical-align: middle;
 }
 
-.meta-categories__link, .post__meta-date, .list__meta-date {
+.meta-categories__link, .post__meta-date, .list__meta-date,  .post__meta-lastmod, .list__meta-lastmod {
 	vertical-align: middle;
 }
 


### PR DESCRIPTION
If a post's frontmatter contains `lastmod`, and if it differs from `date`, display `(Last Modified: )` after the post's initial published date.