### PR TITLE
Feature: Allow font override

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
     post_navigation = true
     postSections = ["post"] # the section pages to show on home page and the "Recent articles" widget
     #postSections = ["blog", "news"] # alternative that shows more than one section's pages
-	font_override = false # Use fonts specified in 'css/fonts.css' instead of HTML hard-coded Open Sans
-	googlefonts_dns_prefetch = false # If using 'font_override' do DNS prefetching for Google fonts
+    font_override = false # Use fonts specified in 'css/fonts.css' instead of HTML hard-coded Open Sans
+    googlefonts_dns_prefetch = false # If using 'font_override' do DNS prefetching for Google fonts
 
 
 [Params.widgets]

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
     post_navigation = true
     postSections = ["post"] # the section pages to show on home page and the "Recent articles" widget
     #postSections = ["blog", "news"] # alternative that shows more than one section's pages
+	font_override = false # Use fonts specified in 'css/fonts.css' instead of HTML hard-coded Open Sans
+	googlefonts_dns_prefetch = false # If using 'font_override' do DNS prefetching for Google fonts
 
 
 [Params.widgets]

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,9 +7,15 @@
 {{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
 {{ .Hugo.Generator }}
 {{ if .Site.Params.opengraph }}{{ template "_internal/opengraph.html" . }}{{ end }}
-<link rel="dns-prefetch" href="//fonts.googleapis.com" />
 {{ if .RSSLink }}<link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }} Feed" href="{{ .RSSLink }}">{{ end }}
+{{ if or (not .Site.Params.font_override) .Site.Params.googlefonts_dns_prefetch }}
+<link rel="dns-prefetch" href="//fonts.gstatic.com" />
+{{ end }}
+{{ if .Site.Params.font_override }}
+<link rel="stylesheet" href="{{ "css/fonts.css" | relURL }}" type="text/css" media="all" />
+{{ else }}
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,400italic,700" type="text/css" media="all" />
+{{ end }}
 <link rel="stylesheet" href="{{ "css/style.css" | relURL }}" type="text/css" media="all" />
 <script type="text/javascript" src="{{ "js/scripts.js" | relURL }}"></script>
 <link rel="shortcut icon" href="{{ "favicon.ico" | relURL }}">

--- a/static/css/fonts.css
+++ b/static/css/fonts.css
@@ -1,0 +1,3 @@
+<style>
+@import url('https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700');
+</style>


### PR DESCRIPTION
Add 2 new site params

1. font_override: Allow hard-coded Open Sans fonts to be replaced by fonts defined in css/fonts.css
2. googlefonts_dns_prefetch: Toggle on or off DNS prefetching for Google fonts when using font_override.

This is a handy feature for those people who may not want their site loading external resources ([Tor](https://www.torproject.org/), [IPFS](http://ipfs.io/), etc).

Also modified the dns-prefetch link.  Per the Chromium [design docs](https://www.chromium.org/developers/design-documents/dns-prefetching#TOC-Manual-Prefetch) `fonts.googleapis.com` should already be prefetched.  Font files themselves are served from `fonts.gstatic.com` so prefetch that instead when using defaults, or when `googlefonts_dns_prefetch` is true if using `font_override`.