### PR TITLE
fixed name of recent articles widget in sidebar partial.

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -5,7 +5,7 @@
 	{{ partial "widgets/social.html" . }}
 	{{ partial "widgets/taglist.html" . }}
 
-	{{- if and (not .Site.Params.widgets.search) (not .Site.Params.widgets.recent) (not .Site.Params.widgets.categories) (not .Site.Params.widgets.social) (not .Site.Params.widgets.taglist) }}
+	{{- if and (not .Site.Params.widgets.search) (not .Site.Params.widgets.recent_articles) (not .Site.Params.widgets.categories) (not .Site.Params.widgets.social) (not .Site.Params.widgets.taglist) }}
 	<p class="sidebar__warning"><strong>WARNING:</strong><br>Please activate at least one sidebar widget.</p>
 	{{- end }}
 </aside>


### PR DESCRIPTION
Fixes an issue where if I activate the recent_articles widget I still get a warning to activate at least one sidebar widget.