### PR TITLE
Add support for logo in the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
 
 [Params]
   subtitle = "Just another site" # Subtitle of your site. Used in site header
+  #logo = "img/logo.svg" # Logo displayed in site header
   description = "John Doe's Personal blog about everything" # Site description. Used in meta description
   #copyright = "John Doe" # copyright holder, otherwise will use site title
   opengraph = true # Enable OpenGraph if true
@@ -133,6 +134,10 @@ For more information about front matter variables read [Hugo Front Matter](https
 The sidebar consists of multiple widgets. Widgets can be enabled individually using the `widgets` key with a list of widget names as value. You can add your own widgets, by placing a template under `layouts/partials/widgets/<name>.html`. The list of widgets can be overwritten from a page's front matter.
 
 Some widget respect optional configuration. Have a look at the `[Params.widgets]` and `[Params.widgets.social]` sections in the example configuration above.
+
+### Logo
+
+**Mainroad** can be customized with your own logo in the site header. You just have to provide a `logo=path/to/your/logo.svg` stanza in your configuration file (see above). Currently, **Mainroad** includes the image at `max-height: 80px`. This might change in the future, thus we expect you to provide the logo in a vector format (`.svg`).
 
 ### Menus
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -14,6 +14,7 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
 [Params]
   subtitle = "Just another site" # Subtitle of your site
   description = "John Doe's Personal blog about everything" # Description of your site
+  logo = "img/placeholder.png"
   opengraph = true
   twitter_cards = false
   readmore = false # Show "Read more" button in list if true

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,11 +1,16 @@
 <header class="header">
 	<div class="container">
-		<div class="logo">
-			<a class="logo__link" href="{{ "" | relLangURL }}" title="{{ .Site.Title }}" rel="home">
+		<a class="logo flex" href="{{ "" | relLangURL }}" title="{{ .Site.Title }}" rel="home">
+			{{ with .Site.Params.logo }}
+			<div>
+				<img class="logo__img" alt="Logo" src="{{ relLangURL . }}" />
+			</div>
+			{{ end }}
+			<div class="logo__text">
 				<div class="logo__title">{{ .Site.Title }}</div>
 				{{ with .Site.Params.subtitle }}<div class="logo__tagline">{{ . }}</div>{{ end }}
-			</a>
-		</div>
+			</div>
+		</a>
 		{{ partial "menu.html" . }}
 	</div>
 </header>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -387,12 +387,21 @@ select {
 }
 
 .logo {
+	-webkit-align-items: center;
+	align-items: center;
+	-webkit-justify-content: flex-start;
+	justify-content: flex-start;
 	padding: 25px;
 }
 
-.logo__link {
+.logo__text {
 	display: inline-block;
 	text-transform: uppercase;
+}
+
+.logo__img {
+	max-height: 5rem;
+	padding-right: 1.5rem;
 }
 
 .logo__title {
@@ -404,8 +413,8 @@ select {
 }
 
 .logo__tagline {
-	display: inline-block;
 	padding-top: 10px;
+	padding-bottom: 4px;
 	margin-top: 10px;
 	font-size: 14px;
 	font-size: .875rem;
@@ -1192,15 +1201,6 @@ textarea {
 		margin: 0;
 	}
 
-	.logo {
-		text-align: center;
-	}
-
-	.logo__title {
-		font-size: 24px;
-		font-size: 1.5rem;
-	}
-
 	.sidebar {
 		margin-top: 20px;
 	}
@@ -1212,6 +1212,25 @@ textarea {
 	input[type=tel],
 	input[type=url] {
 		width: 88%;
+	}
+
+	.logo {
+		display: block;
+		text-align: center;
+	}
+
+	.logo__img {
+		padding-right: 0;
+		padding-bottom: 1rem;
+	}
+
+	.logo__title {
+		font-size: 24px;
+		font-size: 1.5rem;
+	}
+
+	.logo__tagline {
+		padding-bottom: 0;
 	}
 
 	.meta__item {


### PR DESCRIPTION
This adds a left floating logo image to the header. On smaller screens the float is changed to a centered column over title/subtitle.