### PR TITLE
CSS for list.html {{ .Content }}

### DIFF
--- a/exampleSite/content/post/_index.md
+++ b/exampleSite/content/post/_index.md
@@ -1,0 +1,15 @@
+This is the content of `post/_index.md`. It is styled like the
+`{{ .Content }}` of a single page. This is because it is wrapped in the
+`.content` class.
+
+### List
+
+* li
+* [Link](#link)
+  * nested
+  * nested
+* li3
+
+### Link
+
+This [link](#List) is now styled.

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,6 @@
 {{ partial "header.html" . }}
 
-	<main class="main list content" role="main">
+	<main class="main list" role="main">
 		{{- if not .IsHome}}
 		{{- with .Title }}
 		<header class="page-header">
@@ -9,7 +9,7 @@
 		{{- end }}
 		{{- end }}
 		{{- with .Content }}
-		<div class="page-content">
+		<div class="content clearfix">
 			{{ . }}
 		</div>
 		{{- end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,6 @@
 {{ partial "header.html" . }}
 
-<main class="main content">
+<main class="main">
 	<article class="post">
 		<header class="post__header">
 			<h1 class="post__title">{{ .Title }}</h1>
@@ -12,7 +12,7 @@
 		</figure>
 		{{- end }}
 		{{- partial "post_toc.html" . -}}
-		<div class="post__content clearfix">
+		<div class="content clearfix">
 			{{ .Content }}
 		</div>
 		{{ partial "post_tags.html" . }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -76,7 +76,7 @@ body {
 	display: flex;
 }
 
-.content {
+.main {
 	-webkit-flex: 1 0 65.83%;
 	-ms-flex: 1 0 65.83%;
 	flex: 1 0 65.83%;
@@ -537,7 +537,7 @@ select {
 	font-size: 1.75rem;
 }
 
-.page-content {
+.list .content {
 	margin-bottom: 20px;
 	margin-bottom: 1.25rem;
 }
@@ -599,63 +599,63 @@ select {
 	width: 100%;
 }
 
-.post__content a,
+.content a,
 .warning a {
 	font-weight: 700;
 	color: #e64946;
 }
 
-.post__content a:hover,
+.content a:hover,
 .warning a:hover {
 	color: #e64946;
 	text-decoration: underline;
 }
 
-.post__content .alignnone {
+.content .alignnone {
 	display: block;
 	margin: 20px 0;
 	margin: 1.25rem 0;
 }
 
-.post__content .aligncenter {
+.content .aligncenter {
 	display: block;
 	margin: 20px auto;
 	margin: 1.25rem auto;
 }
 
-.post__content .alignleft {
+.content .alignleft {
 	display: inline;
 	float: left;
 	margin: 5px 20px 20px 0;
 	margin: .3125rem 1.25rem 1.25rem 0;
 }
 
-.post__content .alignright {
+.content .alignright {
 	display: inline;
 	float: right;
 	margin: 5px 0 20px 20px;
 	margin: .3125rem 0 1.25rem 1.25rem;
 }
 
-.post__content ul {
+.content ul {
 	list-style: square;
 }
 
-.post__content ol {
+.content ol {
 	list-style: decimal;
 }
 
-.post__content ul,
-.post__content ol {
+.content ul,
+.content ol {
 	margin: 0 0 20px 40px;
 }
 
-.post__content ul ul,
-.post__content ol ol {
+.content ul ul,
+.content ol ol {
 	margin: 0 0 0 40px;
 }
 
-.post__content li {
+.content li {
 	margin-bottom: 5px;
 }
 
@@ -1122,7 +1122,6 @@ textarea {
 		display: block;
 	}
 
-	.content,
 	.sidebar,
 	.body .main {
 		float: none;


### PR DESCRIPTION
This an attempt to fix #77. My approach is to wrap every use of `{{ .Content }}` in the `.content` class to style the generated HTML. This makes the `.post__content` and `.page-content` classes superfluous.

I have added some content to the post list for testing:
![content](https://user-images.githubusercontent.com/11337857/44954948-36fd2300-aeab-11e8-8ffe-0d70f141c33d.png)
