### PR TITLE
Avoid .Scratch. Requires hugo 0.48 and go 1.11.

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,12 +1,11 @@
-{{- $s := newScratch }}
+{{- $sidebar := false }}
 {{- if eq .Kind "home" -}}
-	{{ $s.Set "sb" (default .Site.Params.sidebar.home .Params.sidebar) }}
+	{{ $sidebar = (default .Site.Params.sidebar.home .Params.sidebar) }}
 {{- else if eq .Kind "page" -}}
-	{{ $s.Set "sb" (default .Site.Params.sidebar.single .Params.sidebar) }}
+	{{ $sidebar = (default .Site.Params.sidebar.single .Params.sidebar) }}
 {{- else -}}
-	{{ $s.Set "sb" (default .Site.Params.sidebar.list .Params.sidebar) }}
+	{{ $sidebar = (default .Site.Params.sidebar.list .Params.sidebar) }}
 {{ end }}
-{{- $sidebar := $s.Get "sb" }}
 
 {{- if $sidebar -}}
 <aside class="sidebar{{ if eq $sidebar "left" }} sidebar--left{{ end }}">


### PR DESCRIPTION
This is lying around for a bit now. It works as intended and avoids `.Scratch`. Benchmarks show that it is indeed faster, but only a negligible bit.

with `.Scratch`
```
Average time per operation: 1299ms
Average memory allocated per operation: 368460kB
Average allocations per operation: 8639345
```

without `.Scratch`
```
Average time per operation: 1210ms
Average memory allocated per operation: 367929kB
Average allocations per operation: 8635042
```

site
```                   | DE   
+------------------+-----+
  Pages            | 665  
  Paginator pages  |  61  
  Non-page files   | 803  
  Static files     |  11  
  Processed images |  13  
  Aliases          |   5  
  Sitemaps         |   1  
  Cleaned          |   0 
```

Nevertheless, I think this should eventually be merged because it improves readability. But perhaps we should wait until something else requires the version bump to >= 0.48.