### PR TITLE
Use .Site.Language.Lang for html lang attribute

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js" lang="{{ .Site.LanguageCode | default "en-us" }}">
+<html class="no-js" lang="{{ .Site.Language.Lang | default "en-us" }}">
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
The current variable `.Site.LanguageCode` does not correctly set the html
tag lang attribute for multilingual sites. Instead it only uses the
default language setting.

<https://gohugo.io/variables/page/> describes the page variable
`.Language.Lang` as the most appropriate alternative.