### PR TITLE
Add initial logo image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
   customJS = ["js/custom.js"] # Include custom JS files
 
 [Params.logo]
+  image = "img/placeholder.png" # Logo image. Path relative to "static"
   title = "Mainroad" # Logo title, otherwise will use site title
   subtitle = "Just another site" # Logo subtitle
 
@@ -171,6 +172,22 @@ widgets: # Enable sidebar widgets in given order per page
 
 For more information about front matter variables read
 [Hugo Front Matter](https://gohugo.io/content-management/front-matter) from Hugo official documentation.
+
+### Logo
+
+**Mainroad** allows you to set a custom logo in the site header. You may use text, or image, or both. Use the following
+options in your site config:
+
+```toml
+[Params.logo]
+  image = "img/placeholder.png"
+  title = "Mainroad"
+  subtitle = "Just another site"
+```
+
+Please be noted that the logo image will display at a maximum width of 128 pixels and a maximum height of 128 pixels
+when you use text and image simultaneously. When the only logo image is active, it will display at a maximum height of
+256 pixels. Ideally, your image should be SVG.
 
 ### Sidebar
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -389,7 +389,32 @@ select {
 
 .logo__link {
 	display: inline-block;
+}
+
+.logo__item {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+.logo__img {
+	max-height: 256px;
+}
+
+.logo__text {
 	text-transform: uppercase;
+}
+
+.logo--mixed .logo__item {
+	margin: .5rem auto;
+}
+
+.logo--mixed .logo__img {
+	max-width: 128px;
+	max-height: 128px;
+}
+
+.logo--mixed .logo__text {
+	padding: 0 1rem;
 }
 
 .logo__title {
@@ -1195,6 +1220,10 @@ textarea {
 
 	.logo {
 		text-align: center;
+	}
+
+	.logo__link {
+		margin: 0 auto;
 	}
 
 	.logo__title {

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,11 +1,24 @@
 {{- $logoTitle := .Site.Params.logo.title | default .Site.Title -}}
 {{- $logoSubtitle := .Site.Params.logo.subtitle | default .Site.Params.subtitle -}}
+{{- $logoImage := .Site.Params.logo.image -}}
 
-{{- with $logoTitle }}
-	<div class="logo">
-		<a class="logo__link" href="{{ "" | relLangURL }}" title="{{ . }}" rel="home">
-			<div class="logo__title">{{ . }}</div>
-			{{ with $logoSubtitle }}<div class="logo__tagline">{{ . }}</div>{{ end }}
+{{- if or $logoTitle $logoImage }}
+	{{/* Defined when logo is mixed (image + text) */}}
+	{{- $logoMix := and $logoImage $logoTitle -}}
+
+	<div class="logo{{ with $logoMix }} logo--mixed{{ end }}">
+		<a class="logo__link" href="{{ "" | relLangURL }}"{{ with $logoTitle }} title="{{ . }}"{{ end }} rel="home">
+			{{- with $logoImage }}
+				<div class="logo__item logo__imagebox">
+					<img class="logo__img" src="{{ . | relURL }}">
+				</div>
+			{{- end -}}
+			{{- with $logoTitle -}}
+				<div class="logo__item logo__text">
+					<div class="logo__title">{{ . }}</div>
+					{{ with $logoSubtitle }}<div class="logo__tagline">{{ . }}</div>{{ end }}
+				</div>
+			{{- end }}
 		</a>
 	</div>
 {{- end }}


### PR DESCRIPTION
This PR adds logo image support.

## Why

I try to improve #66 and fix main issue: even if you follow logo image restrictions from README, it takes up a lot of space on mobile devices regardless of the logo image size. Screenshot:

![Screenshot](https://user-images.githubusercontent.com/21033483/82766691-07185080-9def-11ea-93b3-956ff0f9f643.png)

It seems there is enough space on the sides to contain this square logo image.

## Current proposal

The solution resolves the problem, but for limited use-cases.

It's not difficult by itself, but if we want to provide backward compatibility plus a similar look & feel, then we need additional logic and extra CSS classes... Additionally, applying a cascade to BEM increases code coupling. Still, this solution is slightly better. Screenshot: 

![NEW_PR](https://user-images.githubusercontent.com/21033483/82766780-b523fa80-9def-11ea-94be-2f33f16444c5.png)

---

I am also considering restricting images to SVG only.

I plan to postpone this PR until the end of the working week. Until then, I'm open to suggestions or bug reports.
