### PR TITLE
Use highlightColor for code's color

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -268,7 +268,7 @@ code {
 
 code {
 	padding: 0 5px;
-	color: #c33;
+	color: {{ $highlightColor }};
 }
 
 pre {


### PR DESCRIPTION
The color for `<code>` is #c33, which is the default color of mainroad,
(or MH Magazine lite).

Since mainroad allows user to change the default highlight color, the
color for `<code>` should be change as well.