### PR TITLE
Append home page title to / title (if on home)

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>{{ block "title" . }}{{ if not .IsHome }}{{ .Title }} - {{ end }}{{ .Site.Title }}{{ end }}</title>
+	<title>{{ block "title" . }}{{ if not .IsHome }}{{ .Title }} - {{ end }}{{ .Site.Title }}{{ end }}{{ if and ( .Title ) ( .IsHome ) }} - {{ .Title }}{{ end }}</title>
 	<script>(function(d,e){d[e]=d[e].replace("no-js","js");})(document.documentElement,"className");</script>
 	<meta name="description" content="{{ if .IsHome }}{{ .Site.Params.description }}{{ else }}{{ .Params.Description }}{{ end }}">
 	{{- if .Site.Params.opengraph }}


### PR DESCRIPTION
Currently the site home page uses "site title" only in the `<title>` tag

All other pages use format `<title>page_title - site_title</title>`.

For "home page" in search engine, it would be good to be able to provide a "site tagline" on the home page only.

This change will therefore allow the title to be _appended_ on the site home page, ie `<title>site_title - homepage_title</title>`.

To do this, the file `content/_index.md` need simply include `title: ` element as usual: if present, this will be appended to page title of home page.