### PR TITLE
feat: move webfont loading to a partial

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,12 +16,10 @@
 	{{- if .Site.Params.twitter_cards }}
 		{{ template "_internal/twitter_cards.html" . }}
 	{{- end }}
-	<link rel="dns-prefetch" href="//fonts.googleapis.com">
-	<link rel="dns-prefetch" href="//fonts.gstatic.com">
+	{{ partial "webfonts.html" }}
 	{{ with .OutputFormats.Get "rss" -}}
 	{{ printf `<link rel="%s" type="%s" href="%s" title="%s">` .Rel .MediaType.Type .RelPermalink $.Site.Title | safeHTML }}
 	{{ end -}}
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700">
 	{{ $style := resources.Get "css/style.css" | resources.ExecuteAsTemplate "css/style.css" . -}}
 	<link rel="stylesheet" href="{{ $style.RelPermalink }}">
 	{{ range .Site.Params.customCSS -}}

--- a/layouts/partials/webfonts.html
+++ b/layouts/partials/webfonts.html
@@ -1,0 +1,3 @@
+<link rel="dns-prefetch" href="//fonts.googleapis.com">
+<link rel="dns-prefetch" href="//fonts.gstatic.com">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700">


### PR DESCRIPTION
For users of the theme that want a different webfont or no webfonts at all, there's no option other than overriding the entire `baseof.html` file.

This change moves the webfont loading to a new partial file called `webfonts.html`. That way if a user wants a different font or no fonts at all, they only have one small file to override.

The next step for a user would be modifying their custom CSS to use the font where appropriate. `body` for the main typeface and `pre, code, kbd, samp` for monospace.