### PR TITLE
Fix broken authorbox_name string

### DIFF
--- a/i18n/bg.yaml
+++ b/i18n/bg.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "За {{ .Count }}"
+  translation: "За {{ . }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/cs.yaml
+++ b/i18n/cs.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "O {{ .Count }}"
+  translation: "O {{ . }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "Über {{ .Count }}"
+  translation: "Über {{ . }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "About {{ .Count }}"
+  translation: "About {{ . }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "Sobre el autor {{ .Count }}"
+  translation: "Sobre el autor {{ . }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "À propos {{ .Count }}"
+  translation: "À propos {{ . }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/hu.yaml
+++ b/i18n/hu.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "A {{ .Count }} -ról"
+  translation: "A {{ . }} -ról"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "Riguardo {{ .Count }}"
+  translation: "Riguardo {{ . }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "{{ .Count }}について"
+  translation: "{{ . }}について"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/mk.yaml
+++ b/i18n/mk.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "За {{ .Count }}"
+  translation: "За {{ . }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "Over {{ .Count }}"
+  translation: "Over {{ . }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/pt-br.yaml
+++ b/i18n/pt-br.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "Sobre {{ .Count }}"
+  translation: "Sobre {{ . }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "Sobre {{ .Count }}"
+  translation: "Sobre {{ . }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "Об авторе {{ .Count }}"
+  translation: "Об авторе {{ . }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/vi.yaml
+++ b/i18n/vi.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "Về {{ .Count }}"
+  translation: "Về {{ . }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/zh-cn.yaml
+++ b/i18n/zh-cn.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "关于 {{ .Count }}"
+  translation: "关于 {{ . }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/zh-tw.yaml
+++ b/i18n/zh-tw.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "關於 {{ .Count }}"
+  translation: "關於 {{ . }}"
 
 # Sidebar
 - id: sidebar_warning


### PR DESCRIPTION
As described in #237, recent Hugo release broke the theme with warnings.
I think this is not an upstream bug, but behavior change on undefined variable.

This resolves the issue by replacing all occurrences of `{{ .Count }}` with `{{ . }}`.