### PR TITLE
Add a minimum value to display tags in widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
 [Params.widgets]
   recent_num = 5 # Set the number of articles in the "Recent articles" widget
   tags_counter = false # Enable counter for each tag in "Tags" widget
+  tags_min_counter = 1 # Display only tags with a greater value
 
 [Params.widgets.social]
   # Enable parts of social widget

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -33,3 +33,4 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
 [Params.widgets]
   recent_num = 5 # Set the number of articles in the "Recent articles" widget
   tags_counter = false # Enable counter for each tag in "Tags" widget (disabled by default)
+  tags_min_counter = 5 # Display only tags with greateror equal counter, to limit tag list

--- a/layouts/partials/widgets/taglist.html
+++ b/layouts/partials/widgets/taglist.html
@@ -5,9 +5,12 @@
 	<div class="widget__content">
 	{{- range $name, $taxonomy := $tags }}
 		{{- with $.Site.GetPage (printf "/tags/%s" $name) }}
+		{{/* Only render tags with a counter value greater than minimal settings */}}
+		{{- if ge $taxonomy.Count (default 0 .Site.Params.widgets.tags_min_counter) }}
 		<a class="widget-taglist__link widget__link btn" href="{{ .RelPermalink }}" title="{{ .Title }}">
 			{{- .Title -}}{{- if .Site.Params.widgets.tags_counter }} ({{ $taxonomy.Count }}){{ end -}}
 		</a>
+		{{- end }}
 		{{- end }}
 	{{- end }}
 	</div>


### PR DESCRIPTION
The tag list in the Tag widget can be very long.
With such feature, it is possible to limit to the most used tags.