### PR TITLE
Fix i18n authorbox_name string error

### DIFF
--- a/i18n/bg.yaml
+++ b/i18n/bg.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "За {{ .Count }}"
+  translation: "За {{ .Name }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/cs.yaml
+++ b/i18n/cs.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "O {{ .Count }}"
+  translation: "O {{ .Name }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "Über {{ .Count }}"
+  translation: "Über {{ .Name }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "About {{ .Count }}"
+  translation: "About {{ .Name }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "Sobre el autor {{ .Count }}"
+  translation: "Sobre el autor {{ .Name }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "À propos {{ .Count }}"
+  translation: "À propos {{ .Name }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/hu.yaml
+++ b/i18n/hu.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "A {{ .Count }} -ról"
+  translation: "A {{ .Name }} -ról"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "Riguardo {{ .Count }}"
+  translation: "Riguardo {{ .Name }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "{{ .Count }}について"
+  translation: "{{ .Name }}について"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/mk.yaml
+++ b/i18n/mk.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "За {{ .Count }}"
+  translation: "За {{ .Name }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "Over {{ .Count }}"
+  translation: "Over {{ .Name }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/pt-br.yaml
+++ b/i18n/pt-br.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "Sobre {{ .Count }}"
+  translation: "Sobre {{ .Name }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "Sobre {{ .Count }}"
+  translation: "Sobre {{ .Name }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "Об авторе {{ .Count }}"
+  translation: "Об авторе {{ .Name }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/vi.yaml
+++ b/i18n/vi.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "Về {{ .Count }}"
+  translation: "Về {{ .Name }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/zh-cn.yaml
+++ b/i18n/zh-cn.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "关于 {{ .Count }}"
+  translation: "关于 {{ .Name }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/i18n/zh-tw.yaml
+++ b/i18n/zh-tw.yaml
@@ -28,7 +28,7 @@
 
 # Authorbox
 - id: authorbox_name
-  translation: "關於 {{ .Count }}"
+  translation: "關於 {{ .Name }}"
 
 # Sidebar
 - id: sidebar_warning

--- a/layouts/partials/authorbox.html
+++ b/layouts/partials/authorbox.html
@@ -12,7 +12,7 @@
 	{{- end }}
 	{{- with .Site.Author.name }}
 	<div class="authorbox__header">
-		<span class="authorbox__name">{{ T "authorbox_name" . }}</span>
+		<span class="authorbox__name">{{ T "authorbox_name" (dict "Name" .) }}</span>
 	</div>
 	{{- end }}
 	{{- with .Site.Author.bio }}


### PR DESCRIPTION
This is due to an upstream issue in Hugo ≥0.76 (Upgrade to go-i18n v2). Three months have passed, so I have to look for workarounds on our side.

The most popular option (replace `{{ .Count }}` to `{{ . }}`) doesn't suit us because it breaks backward compatibility. This fix will allow us to preserve backward compatibility with older versions.

Fix #237