### PR TITLE
Fix empty TOC block

### DIFF
--- a/layouts/partials/post_toc.html
+++ b/layouts/partials/post_toc.html
@@ -1,8 +1,10 @@
-{{ if .Param "toc" }}
+{{- if .Param "toc" }}
+{{- if gt (len .TableOfContents) 32 }}<!-- Issue #247 -->
 <div class="post__toc toc">
 	<div class="toc__title">{{ T "toc_title" }}</div>
 	<div class="toc__menu">
 		{{ .TableOfContents }}
 	</div>
 </div>
-{{ end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
This PR fixes empty TOC blocks for both markdown renderers (goldmark & blackfriday). Besides
checking param state, we additionally check that length of the TOC block itself is greater
than 32 characters (`<nav id="TableOfContents"></nav>` == 32).

I dislike this check as any others based on unstable magic numbers, but it is what it is.

Fix #247