### PR TITLE
add supports for utteranc.es comments

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -19,6 +19,18 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
   authorbox = true
   pager = true
   post_meta = ["date", "categories"] # Order of post meta information
+  
+  # support for utteranc.es
+  # for detail, please refer to: https://utteranc.es/?installation_id=15052636&setup_action=install
+  utteranc_comment = true     # to enable utteranc.es comment plugin                
+  utteranc_repo = ""          # "owner/repo"
+  utteranc_src = "https://utteranc.es/client.js"       
+  utteranc_issue_term = "pathname"                     
+  utteranc_label = "utteranc-comment"                  
+  utteranc_theme = "github-light"                      
+  utteranc_cross_origin = "anonymous"                  
+
+  
 
 [Params.logo]
   subtitle = "Just another site" # Logo subtitle

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -19,10 +19,9 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
   authorbox = true
   pager = true
   post_meta = ["date", "categories"] # Order of post meta information
-  
   # support for utteranc.es
   # for detail, please refer to: https://utteranc.es/?installation_id=15052636&setup_action=install
-  utteranc_comment = true     # to enable utteranc.es comment plugin                
+  utteranc_comment = true     # to enable utteranc.es comment plugin
   utteranc_repo = ""          # "owner/repo"
   utteranc_src = "https://utteranc.es/client.js"
   utteranc_issue_term = "pathname"
@@ -30,7 +29,7 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
   utteranc_theme = "github-light"
   utteranc_cross_origin = "anonymous"
 
-  
+
 
 [Params.logo]
   subtitle = "Just another site" # Logo subtitle

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -24,11 +24,11 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
   # for detail, please refer to: https://utteranc.es/?installation_id=15052636&setup_action=install
   utteranc_comment = true     # to enable utteranc.es comment plugin                
   utteranc_repo = ""          # "owner/repo"
-  utteranc_src = "https://utteranc.es/client.js"       
-  utteranc_issue_term = "pathname"                     
-  utteranc_label = "utteranc-comment"                  
-  utteranc_theme = "github-light"                      
-  utteranc_cross_origin = "anonymous"                  
+  utteranc_src = "https://utteranc.es/client.js"
+  utteranc_issue_term = "pathname"
+  utteranc_label = "utteranc-comment"
+  utteranc_theme = "github-light"
+  utteranc_cross_origin = "anonymous"
 
   
 

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -5,4 +5,3 @@
 {{ else if and .Site.Params.utteranc_comment .Site.Params.utteranc_repo (index .Params "comments" | default "true") (not .Site.IsServer) }}
 <script src="{{ $.Site.Params.utteranc_src | default "https://utteranc.es/client.js" }}" repo="{{ $.Site.Params.utteranc_repo }}" issue-term="{{ $.Site.Params.utteranc_issue_term | default "pathname" }}" {{ with .Site.Params.utteranc_label }} label="{{ . }}" {{ end }} theme="{{ $.Site.Params.utteranc_theme | default "github-light" }}" crossorigin="{{ $.Site.Params.utteranc_cross_origin | default "anonymous" }}" async></script>
 {{ end }}
-

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -5,3 +5,4 @@
 {{ else if and .Site.Params.utteranc_comment .Site.Params.utteranc_repo (index .Params "comments" | default "true") (not .Site.IsServer) }}
 <script src="{{ $.Site.Params.utteranc_src | default "https://utteranc.es/client.js" }}" repo="{{ $.Site.Params.utteranc_repo }}" issue-term="{{ $.Site.Params.utteranc_issue_term | default "pathname" }}" {{ with .Site.Params.utteranc_label }} label="{{ . }}" {{ end }} theme="{{ $.Site.Params.utteranc_theme | default "github-light" }}" crossorigin="{{ $.Site.Params.utteranc_cross_origin | default "anonymous" }}" async></script>
 {{ end }}
+

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -2,4 +2,15 @@
 <section class="comments">
 	{{ template "_internal/disqus.html" . }}
 </section>
+{{ else if and .Site.Params.utteranc_comment .Site.Params.utteranc_repo (index .Params "comments" | default "true") (not .Site.IsServer) }}
+<script src="{{ $.Site.Params.utteranc_src | default "https://utteranc.es/client.js" }}"
+        repo="{{ $.Site.Params.utteranc_repo }}"
+        issue-term="{{ $.Site.Params.utteranc_issue_term | default "pathname" }}"
+        {{ with .Site.Params.utteranc_label }}
+        label="{{ . }}"
+        {{ end }}
+        theme="{{ $.Site.Params.utteranc_theme | default "github-light" }}"
+        crossorigin="{{ $.Site.Params.utteranc_cross_origin | default "anonymous" }}"
+  async>
+</script>
 {{ end }}

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -3,14 +3,5 @@
 	{{ template "_internal/disqus.html" . }}
 </section>
 {{ else if and .Site.Params.utteranc_comment .Site.Params.utteranc_repo (index .Params "comments" | default "true") (not .Site.IsServer) }}
-<script src="{{ $.Site.Params.utteranc_src | default "https://utteranc.es/client.js" }}"
-        repo="{{ $.Site.Params.utteranc_repo }}"
-        issue-term="{{ $.Site.Params.utteranc_issue_term | default "pathname" }}"
-        {{ with .Site.Params.utteranc_label }}
-        label="{{ . }}"
-        {{ end }}
-        theme="{{ $.Site.Params.utteranc_theme | default "github-light" }}"
-        crossorigin="{{ $.Site.Params.utteranc_cross_origin | default "anonymous" }}"
-  async>
-</script>
+<script src="{{ $.Site.Params.utteranc_src | default "https://utteranc.es/client.js" }}" repo="{{ $.Site.Params.utteranc_repo }}" issue-term="{{ $.Site.Params.utteranc_issue_term | default "pathname" }}" {{ with .Site.Params.utteranc_label }} label="{{ . }}" {{ end }} theme="{{ $.Site.Params.utteranc_theme | default "github-light" }}" crossorigin="{{ $.Site.Params.utteranc_cross_origin | default "anonymous" }}" async></script>
 {{ end }}


### PR DESCRIPTION
> [utteranc.es](https://utteranc.es/?installation_id=15052636&setup_action=install) is a lightweight comments widget built on GitHub issues.

this MR introduce a comment widget support for Mainroad theme by slightly modification of **_layouts/partials/comments.html_**

screenshots as below:
![screenshot](https://github.com/Hazy2019/nzt2019base/blob/master/content/resources/screen_comments.png?raw=true)