### PR TITLE
Add support for Google Analytics 4

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -37,7 +37,11 @@
 
 	<link rel="shortcut icon" href="{{ "favicon.ico" | relURL }}">
 	{{- if not .Site.IsServer }}
+		{{- if hasPrefix .Site.GoogleAnalytics "G-" }}
+		{{ template "_internal/google_analytics.html" . }}
+		{{- else }}
 		{{ template "_internal/google_analytics_async.html" . }}
+		{{- end }}
 	{{- end }}
 </head>
 <body class="body">


### PR DESCRIPTION
Hugo added Google Analytics 4 support to internal template `_internal/google_analytics.html`, but `Mainroad` includes only `_internal/google_analytics_async.html` template that does not work with `G-*` GA ids.

https://github.com/gohugoio/hugo/commit/ba16a14c6e884e309380610331aff78213f84751#diff-25f24f01856ed7f32bf39aafd2dcf3ebc1fb9835162d1057e2d84cb9446936c6