### PR TITLE
Add a FLoC opt-out parameter

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,6 +16,9 @@
 	{{- if .Site.Params.twitter_cards }}
 		{{ template "_internal/twitter_cards.html" . }}
 	{{- end }}
+	{{- if not .Site.Params.floc_optin }}
+	<meta http-equiv="Permissions-Policy" content="interest-cohort=()"/>
+	{{- end }}
 
 	{{- $googleFontsLink := .Site.Params.googleFontsLink | default "https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700" }}
 	{{- if hasPrefix $googleFontsLink "https://fonts.googleapis.com/" }}


### PR DESCRIPTION
Adds a `floc_optin` boolean to the site parameters.

Unless users specifically opt-in, Mainroad will emit `<meta http-equiv="Permissions-Policy" content="interest-cohort=()"/>` via `layouts/_default/baseof`.