### PR TITLE
Fix Goldmark TOC indentation

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -802,20 +802,24 @@ button:not(:-moz-focusring):focus > .menu__btn-title {
 	list-style: none;
 }
 
-.toc__menu ul ul ul a {
+.toc__menu li li a {
 	padding-left: 25px;
 }
 
-.toc__menu ul ul ul ul a {
+.toc__menu li li li a {
 	padding-left: 45px;
 }
 
-.toc__menu ul ul ul ul ul a {
+.toc__menu li li li li a {
 	padding-left: 65px;
 }
 
-.toc__menu ul ul ul ul ul ul a {
+.toc__menu li li li li li a {
 	padding-left: 85px;
+}
+
+.toc__menu li li li li li li a {
+	padding-left: 105px;
 }
 
 .toc__menu li {


### PR DESCRIPTION
This PR fixes Goldmark TOC indentation. Not perfect, but fixes Goldmark and respect blackfriday simultaneously (looks slightly different now).

See screenshots below for comparison.

<details>
  <summary>Before</summary>

  | Goldmark                      | blackfriday                   |
  |-----------------------|-----------------------|
  | [![Mainroad Goldmark TOC before](https://user-images.githubusercontent.com/21033483/124798484-6668ef80-df21-11eb-8ac0-eb625c7f355f.png)](https://user-images.githubusercontent.com/21033483/124798484-6668ef80-df21-11eb-8ac0-eb625c7f355f.png) | [![Mainroad blackfriday TOC before](https://user-images.githubusercontent.com/21033483/124798617-8ef0e980-df21-11eb-826f-50e18a923960.png)](https://user-images.githubusercontent.com/21033483/124798617-8ef0e980-df21-11eb-826f-50e18a923960.png) |

</details>

<details>
  <summary>After</summary>

  | Goldmark                      | blackfriday                   |
  |-----------------------|-----------------------|
  | [![Mainroad Goldmark TOC after](https://user-images.githubusercontent.com/21033483/124798700-aa5bf480-df21-11eb-87a5-958b014ee614.png)](https://user-images.githubusercontent.com/21033483/124798700-aa5bf480-df21-11eb-87a5-958b014ee614.png) | [![Mainroad blackfriday TOC after](https://user-images.githubusercontent.com/21033483/124798799-ca8bb380-df21-11eb-8db9-b9be84f45924.png)](https://user-images.githubusercontent.com/21033483/124798799-ca8bb380-df21-11eb-8db9-b9be84f45924.png) |

</details>

Note that the `markup.tableOfContents.ordered` parameter is not supported.

---

Closes #243
