### PR TITLE
Split up thumbnail into separate partial

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,11 +10,7 @@
 			<div class="post__meta meta">{{ . }}</div>
 			{{- end }}
 		</header>
-		{{- if .Params.thumbnail }}
-		<figure class="post__thumbnail">
-			<img src="{{ .Params.thumbnail | relURL }}" alt="{{ .Title }}">
-		</figure>
-		{{- end }}
+		{{ partial "post_thumbnail.html" (dict "class" "post" "page" .) }}
 		{{- partial "post_toc.html" . -}}
 		<div class="content post__content clearfix">
 			{{ .Content }}

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -1,11 +1,5 @@
 <article class="list__item post">
-	{{- if .Params.thumbnail }}
-	<figure class="list__thumbnail">
-		<a href="{{ .Permalink }}">
-			<img src="{{ .Params.thumbnail | relURL }}" alt="{{ .Title }}" />
-		</a>
-	</figure>
-	{{- end }}
+	{{ partial "post_thumbnail.html" (dict "class" "list" "page" .) }}
 	<header class="list__header">
 		<h2 class="list__title post__title">
 			<a href="{{ .RelPermalink }}" rel="bookmark">

--- a/layouts/partials/post_thumbnail.html
+++ b/layouts/partials/post_thumbnail.html
@@ -1,0 +1,7 @@
+{{- if $thumbnail := .page.Params.thumbnail }}
+<figure class="{{ with .class }}{{ . }}__thumbnail {{ end }}thumbnail">
+	{{ if eq .class "list" }}<a class="thumbnail__link" href="{{ .page.RelPermalink }}">{{ end }}
+		<img class="thumbnail__image" src="{{ $thumbnail | relURL }}" alt="{{ .page.Title }}">
+	{{ if eq .class "list" }}</a>{{ end }}
+</figure>
+{{- end }}


### PR DESCRIPTION
This PR splits up thumbnail include into separate partial.

Preparation for the next PR. This change is required to avoid code duplication, especially after we add support for thumbnail visibility (#160).

