### PR TITLE
Add thumbnail visibility param

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
   title = "Mainroad" # Logo title, otherwise will use site title
   subtitle = "Just another site" # Logo subtitle
 
+[Params.thumbnail]
+  visibility = ["list", "post"] # Control thumbnail visibility
+
 [Params.sidebar]
   home = "right" # Configure layout for home page
   list = "left"  # Configure layout for list pages
@@ -194,6 +197,28 @@ options in your site config:
 Please be noted that the logo image will display at a maximum width of 128 pixels and a maximum height of 128 pixels
 when you use text and image simultaneously. When the only logo image is active, it will display at a maximum height of
 256 pixels. Ideally, your image should be SVG.
+
+### Thumbnail visibility
+
+By default, a thumbnail image has shown for a list and single pages simultaneously. In some cases, you may want to show
+a thumbnail for list-like pages only and hide it on single pages (or vice versa). Control global thumbnail visibility
+via config.
+
+```toml
+[Params.thumbnail]
+  visibility = ["list"]
+```
+
+Besides global configuration, you can change thumbnail visibility individually with extended thumbnail notation via
+front matter.
+
+```yaml
+thumbnail:
+  src: "img/placeholder.jpg"
+  visibility:
+    - list
+    - post
+```
 
 ### Sidebar
 

--- a/layouts/partials/post_thumbnail.html
+++ b/layouts/partials/post_thumbnail.html
@@ -1,7 +1,19 @@
 {{- if $thumbnail := .page.Params.thumbnail }}
-<figure class="{{ with .class }}{{ . }}__thumbnail {{ end }}thumbnail">
-	{{ if eq .class "list" }}<a class="thumbnail__link" href="{{ .page.RelPermalink }}">{{ end }}
+	{{- $class := .class }}
+	{{- $visibility := .page.Site.Params.thumbnail.visibility | default (slice "list" "post") }}
+
+	{{- $valueType := printf "%T" $thumbnail -}}
+	{{- $isMap := in $valueType "map" -}}
+	{{- if $isMap }}
+		{{ $visibility = default (slice "list" "post") (default .page.Site.Params.thumbnail.visibility $thumbnail.visibility) }}
+		{{ $thumbnail = $thumbnail.src }}
+	{{- end }}
+
+	{{- if in $visibility $class }}
+	<figure class="{{ with $class }}{{ . }}__thumbnail {{ end }}thumbnail">
+		{{ if eq $class "list" }}<a class="thumbnail__link" href="{{ .page.RelPermalink }}">{{ end }}
 		<img class="thumbnail__image" src="{{ $thumbnail | relURL }}" alt="{{ .page.Title }}">
-	{{ if eq .class "list" }}</a>{{ end }}
-</figure>
+		{{ if eq $class "list" }}</a>{{ end }}
+	</figure>
+	{{- end }}
 {{- end }}


### PR DESCRIPTION
This PR adds thumbnail visibility params. Such settings allow you to turn off thumbnails for list-like or single pages globally and per page.

Tested on Hugo 0.48, Hugo 0.88.1

Fixes #160
Closes #175