### PR TITLE
Merge two search widgets into one

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,6 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
   single = false # Configure layout for single pages
   # Enable widgets in given order
   widgets = ["search", "recent", "categories", "taglist", "social", "languages"]
-  # alternatively "ddg-search" can be used, to search via DuckDuckGo
-  # widgets = ["ddg-search", "recent", "categories", "taglist", "social", "languages"]
 
 [Params.widgets]
   recent_num = 5 # Set the number of articles in the "Recent articles" widget
@@ -140,6 +138,11 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
 [[Params.widgets.social.custom]]
   title = "My Home Page"
   url = "https://example.com"
+
+[Params.widgets.search]
+  url = "https://google.com/search"
+  input.name = "sitesearch"
+  input.pre = ""
 ```
 
 **Do not copy example config as-is**. Use only those parameters that you need.

--- a/exampleSite/content/docs/customization.md
+++ b/exampleSite/content/docs/customization.md
@@ -130,6 +130,8 @@ Full list of available default widgets:
 
 * `search`, `ddg-search`, `recent`, `categories`, `taglist`, `social`, `languages`
 
+**Note**: DuckDuckGo widget (`ddg-search`) deprecated in favor of `search` widget.
+
 ---
 
 Some of our widgets respect optional configuration. Have a look at the `[Params.widgets]` and `[Params.widgets.social]`
@@ -184,6 +186,41 @@ custom SVG icon needs these attributes:
 
 ```html
 <svg class="{{ with .class }}{{ . }} {{ end }} icon" width="24" height="24">...</svg>
+```
+
+### Search box widget
+
+The search box widget can refer to the results of Google, Bing, and DuckDuckGo searches. By default, Mainroad uses
+Google search if no additional configuration options are specified.
+
+To use a different search engine, first of all, check that the search widget is enabled. Then set the search parameters
+(`Site.Params.widgets.search` section) according to the data below.
+
+**Google (default)**:
+
+```toml
+[Params.widgets.search]
+  url = "https://google.com/search"
+  input.name = "sitesearch"
+  input.pre = ""
+```
+
+**DuckDuckGo**:
+
+```toml
+[Params.widgets.search]
+  url = "https://duckduckgo.com/"
+  input.name = "sites"
+  input.pre = ""
+```
+
+**Bing**:
+
+```toml
+[Params.widgets.search]
+  url = "https://www.bing.com/search"
+  input.name = "q1"
+  input.pre = "site:"
 ```
 
 ### Menus

--- a/layouts/partials/widgets/ddg-search.html
+++ b/layouts/partials/widgets/ddg-search.html
@@ -1,3 +1,4 @@
+<!-- DEPRECATED WIDGET! DON'T USE IT! -->
 <div class="widget-search widget">
 	<form class="widget-search__form" role="search" method="get" action="https://duckduckgo.com/">
 		<label>

--- a/layouts/partials/widgets/search.html
+++ b/layouts/partials/widgets/search.html
@@ -1,9 +1,13 @@
+{{- $actionURL := .Site.Params.widgets.search.url | default "https://google.com/search" -}}
+{{- $inputName := .Site.Params.widgets.search.input.name | default "sitesearch" -}}
+{{- $inputPre := .Site.Params.widgets.search.input.pre -}}
+
 <div class="widget-search widget">
-	<form class="widget-search__form" role="search" method="get" action="https://google.com/search">
+	<form class="widget-search__form" role="search" method="get" action="{{ $actionURL }}">
 		<label>
 			<input class="widget-search__field" type="search" placeholder="{{ T "search_placeholder" }}" value="" name="q" aria-label="{{ T "search_placeholder" }}">
 		</label>
 		<input class="widget-search__submit" type="submit" value="Search">
-		<input type="hidden" name="sitesearch" value="{{ .Site.BaseURL }}" />
+		{{ if $inputName -}}<input type="hidden" name="{{ $inputName }}" value="{{ $inputPre }}{{ .Site.BaseURL }}">{{- end }}
 	</form>
 </div>


### PR DESCRIPTION
This PR combines two different versions of search into one (`search.html`, `ddg-search.html`).

* `search.html` widget: add configurable params (`url`, `input.name`, `input.pre`)
* `ddg-search.html`: add deprecation warning
* Add search box customization guide
* Update README: add `params.widgets.search` example
* Update README: remove mentions of ddg-search widget

Fixes #297