### PR TITLE
Add custom content placeholder in <head>

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -43,6 +43,7 @@
 		{{ template "_internal/google_analytics_async.html" . }}
 		{{- end }}
 	{{- end }}
+	{{ partial "head_custom.html" . }}
 </head>
 <body class="body">
 	<div class="container container--outer">


### PR DESCRIPTION
New partial to make it easier to add custom elements to the page's `<head>` (e.g. `<link>` tags). Currently we need to copy and edit the whole `baseof.html`, which makes it harder to update to a more recent version of the theme.