### PR TITLE
Support custom rel attribute in custom social link

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
 [[Params.widgets.social.custom]]
   title = "My Home Page"
   url = "https://example.com"
+  rel = "me" # Optional. The default is "noopener noreferrer". Set to false to remove the rel attribute
 
 [Params.widgets.search]
   url = "https://google.com/search"

--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
   title = "Youtube"
   url = "https://youtube.com/user/username"
   icon = "youtube.svg" # Optional. Path relative to "layouts/partials"
+  rel = "noopener noreferrer" # Set to false to remove the rel attribute
 
 [[Params.widgets.social.custom]]
   title = "My Home Page"
   url = "https://example.com"
-  rel = "me" # Optional. The default is "noopener noreferrer". Set to false to remove the rel attribute
 
 [Params.widgets.search]
   url = "https://google.com/search"

--- a/exampleSite/content/docs/customization.md
+++ b/exampleSite/content/docs/customization.md
@@ -188,6 +188,20 @@ custom SVG icon needs these attributes:
 <svg class="{{ with .class }}{{ . }} {{ end }} icon" width="24" height="24">...</svg>
 ```
 
+You can also specify the `rel` attribute for the link. By default, the attribute value is `"noopener noreferrer"`. You can remove the attribute completely by setting its value to `false`.
+
+```toml
+[[Params.widgets.social.custom]]
+  title = "My Home Page"
+  url = "https://example.com"
+  rel = "me"
+
+[[Params.widgets.social.custom]]
+  title = "Youtube"
+  url = "https://youtube.com/user/username"
+  rel = false
+```
+
 ### Search box widget
 
 The search box widget can refer to the results of Google, Bing, and DuckDuckGo searches. By default, Mainroad uses

--- a/layouts/partials/widgets/social.html
+++ b/layouts/partials/widgets/social.html
@@ -77,7 +77,7 @@
 
 		{{ range .Site.Params.widgets.social.custom }}
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="{{ .title }}" rel="noopener noreferrer" href="{{ .url }}" target="_blank">
+			<a class="widget-social__link widget__link btn" title="{{ .title }}" rel="{{ .rel | default "noopener noreferrer" }}" href="{{ .url }}" target="_blank">
 				{{- if .icon }}
 					{{ partial .icon (dict "class" "widget-social__link-icon") }}
 				{{- end }}

--- a/layouts/partials/widgets/social.html
+++ b/layouts/partials/widgets/social.html
@@ -77,7 +77,7 @@
 
 		{{ range .Site.Params.widgets.social.custom }}
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="{{ .title }}" rel="{{ .rel | default "noopener noreferrer" }}" href="{{ .url }}" target="_blank">
+			<a class="widget-social__link widget__link btn" title="{{ .title }}" {{ with .rel | default "noopener noreferrer" }} rel="{{ . }}"{{ end }} href="{{ .url }}" target="_blank">
 				{{- if .icon }}
 					{{ partial .icon (dict "class" "widget-social__link-icon") }}
 				{{- end }}


### PR DESCRIPTION
As discussed in #307 

Note: specifying `rel = ""` in config.toml doesn't override the default (`noopener noreferrer`), because it's the same as not specifying `rel` at all. So at the moment there's no clean way to emit an empty `rel` attribute (or to not emit it at all). But it's possible to set `rel` to `" "`, which achieves the same result. Not sure if this is a problem...

(btw, I think `noopener noreferrer` is redundant, because [`noreferrer` implies `noopener`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#attr-noreferrer))

Also, you mentioned in #307 that we should only do this for `custom` links, but why? I think it would make sense to use `rel="me"` for all social links (in fact, it would make sense to make it the default).