### PR TITLE
Add widget caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
   tags_counter = false # Enable counter for each tag in "Tags" widget
 
 [Params.widgets.social]
+  cached = false # activate cache if true
   # Enable parts of social widget
   facebook = "username"
   twitter = "username"
@@ -141,6 +142,7 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
   url = "https://example.com"
 
 [Params.widgets.search]
+  cached = false # activate cache if true
   url = "https://google.com/search"
   [Params.widgets.search.input]
     name = "sitesearch"

--- a/exampleSite/content/docs/customization.md
+++ b/exampleSite/content/docs/customization.md
@@ -158,6 +158,46 @@ sections in the example below.
   email = "example@example.com"
 ```
 
+### Widget caching
+
+Sidebar strongly affects overall build time, especially if you are using all of our widgets or even more. Widget caching
+can significantly improve the generation time. Cached partials remain the same for all affected pages and are not
+generated multiple times by Hugo. All built-in widgets (`search`, `recent`, `categories`, `social`, `languages`) support
+caching.
+
+Add `cached = true` inside the corresponding widget's dictionary table to activate caching. For example, to cache the
+`recent` widget:
+
+```toml
+[Params.widgets.recent]
+  cached = true
+```
+
+The following sample configuration extract shows how to cache all standard widgets and generate your website faster:
+
+```toml
+[Params.widgets.search]
+  cached = true
+
+[Params.widgets.recent]
+  cached = true
+
+[Params.widgets.categories]
+  cached = true
+
+[Params.widgets.taglist]
+  cached = true
+
+[Params.widgets.social]
+  cached = true
+
+[Params.widgets.languages]
+  cached = true
+```
+
+Not all widgets are cacheable. If a widget contains (can contain) different data for different pages (e.g., for TOC
+generation), then it should not be cached. Always check that your modified/customized widget is cached correctly.
+
 ### Social Widget: custom links
 
 **Mainroad** contains built-in social links in the social widget. In addition to default social links, you may set

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -12,8 +12,16 @@
 {{- $root := . }}
 {{- with (default .Site.Params.sidebar.widgets .Params.widgets) -}}
 	{{- range $widget := . }}
-		{{- $p := printf "widgets/%s.html" $widget }}
-		{{- partial $p $root }}
+		{{- $widgetPath := printf "widgets/%s.html" $widget }}
+		{{- $widgetCached := false }}
+		{{- if isset $.Site.Params "widgets" }}
+			{{- $widgetCached = (index $.Site.Params.widgets $widget).cached }}
+		{{- end }}
+		{{- if eq $widgetCached true }}
+			{{- partialCached $widgetPath $root }}
+		{{- else }}
+			{{- partial $widgetPath $root }}
+		{{- end }}
 	{{- end }}
 {{- else }}
 	<p class="sidebar__warning"><strong>{{ T "sidebar_warning" }}:</strong><br>{{ T "sidebar_recommendation" }}</p>


### PR DESCRIPTION
This PR adds configurable widget caching. **This change should reduce the generation times if you can use cached parameters for all or at least part of the widgets.**

Sidebar strongly affects overall build time, especially if you are using all of our widgets or even more. If caching is enabled, cached partials remain the same for all affected pages and are not generated multiple times by Hugo. All built-in widgets (`search`, `recent`, `categories`, `taglist`, `social`, `languages`) support caching.

The implementation logic is simple: if a widget is manually marked as cached in the config, we use the `partialCached` function for calling it, else we use `partial`. There are no plans to complicate things further.

**Relevant config extract:**

<details>
    <summary>Default widgets</summary>

```
[Params.sidebar]
  home = "right"
  list = "right"
  single = "right"
  widgets = ["search", "recent", "categories", "taglist", "social", "languages"]

[Params.widgets]
  recent_num = 5
  tags_counter = false

[Params.widgets.social]
  facebook = "username"
  twitter = "username"
  instagram = "username"
  linkedin = "username"
  telegram = "username"
  github = "username"
  gitlab = "username"
  bitbucket = "username"
  email = "example@example.com"
```

</details>


<details>
    <summary>Cached widgets</summary>

```
[Params.sidebar]
  home = "right"
  list = "right"
  single = "right"
  widgets = ["search", "recent", "categories", "taglist", "social", "languages"]

[Params.widgets]
  recent_num = 5
  tags_counter = false

[Params.widgets.search]
  cached = true

[Params.widgets.recent]
  cached = true

[Params.widgets.categories]
  cached = true

[Params.widgets.taglist]
  cached = true

[Params.widgets.social]
  cached = true
  facebook = "username"
  twitter = "username"
  instagram = "username"
  linkedin = "username"
  telegram = "username"
  github = "username"
  gitlab = "username"
  bitbucket = "username"
  email = "example@example.com"

[Params.widgets.languages]
  cached = true
```

</details>

**Performance:**

<details>
    <summary>Hugo v0.110.0</summary>

`hugo v0.110.0-e32a493b7826d02763c3b79623952e625402b168 linux/amd64 BuildDate=2023-01-17T12:16:09Z VendorInfo=gohugoio`

| This PR | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| sidebar | 31.669 ± 0.121 | 31.454 | 31.860 | 1.86 ± 0.02 |
| sidebar + cached widgets | 20.009 ± 0.085 | 19.909 | 20.148 | 1.18 ± 0.01 |
| no sidebar | 17.012 ± 0.157 | 16.786 | 17.274 | 1.00 ± 0.01 |
| **CURRENT MASTER** | **Mean [s]** | **Min [s]** | **Max [s]** | **Relative** |
| sidebar | 31.636 ± 0.077 | 31.528 | 31.741 | 1.86 ± 0.02 |
| no sidebar| 17.007 ± 0.151 | 16.670 | 17.191 | 1.00 |

</details>


<details>
    <summary>Hugo v0.92.2</summary>

`hugo v0.92.2-CDF6A0D6 linux/amd64 BuildDate=2022-02-11T14:17:39Z VendorInfo=gohugoio`

| This PR | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| sidebar | 44.943 ± 0.091 | 44.838 | 45.118 | 2.42 ± 0.01 |
| sidebar + cached widgets | 20.841 ± 0.087 | 20.645 | 20.933 | 1.12 ± 0.01 |
| no sidebar | 18.633 ± 0.209 | 18.277 | 18.923 | 1.00 ± 0.01 |
| **CURRENT MASTER** | **Mean [s]** | **Min [s]** | **Max [s]** | **Relative** |
| sidebar | 44.754 ± 0.095 | 44.617 | 44.873 | 2.41 ± 0.01 |
| no sidebar | 18.583 ± 0.088 | 18.398 | 18.697 | 1.00 |

</details>

<details>
    <summary>Hugo v0.48</summary>

`Hugo Static Site Generator v0.48 linux/amd64 BuildDate: 2018-08-29T06:33:51Z`

| This PR | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| sidebar | 51.167 ± 0.285 | 50.689 | 51.674 | 2.83 ± 0.04 |
| sidebar + cached widgets | 21.117 ± 0.255 | 20.689 | 21.542 | 1.17 ± 0.02 |
| no sidebar | 18.053 ± 0.221 | 17.679 | 18.459 | 1.00 |
| **CURRENT MASTER** | **Mean [s]** | **Min [s]** | **Max [s]** | **Relative** |
| sidebar | 51.069 ± 0.177 | 50.751 | 51.363 | 2.83 ± 0.04 |
| no sidebar | 18.076 ± 0.265 | 17.698 | 18.543 | 1.00 ± 0.02 |

</details>

Example content contains ≈5000 pages, sidebar includes `"search", "recent", "categories", "taglist", "social", "languages"`. My runners aren't powerful, so don't pay too much attention to absolute numbers.

---

It would be great if someone could test this on their content/website and write about how much less generation time it takes. I would also appreciate any bug reports or grammar checking. If all goes well, I plan to merge this PR around in the middle of April 2023.