### PR TITLE
Localize post meta dates

### DIFF
--- a/exampleSite/content/docs/customization.md
+++ b/exampleSite/content/docs/customization.md
@@ -80,6 +80,16 @@ Full list of available default post meta fields:
 In addition to the default meta fields, you can add your own by placing a custom partial under
 `layouts/partials/post_meta/<name>.html`.
 
+#### Post meta: `date` localization
+
+With [Hugo v0.87.0](https://gohugo.io/news/0.87.0-relnotes/) (or later), `date` meta field shows localized dates (with
+weekdays and months in the current language) by default. In most cases, such a transition is painless, but owners of
+multilingual sites should be careful and check that everything translates as expected after the upgrade.
+
+You can also use a predefined layout, like `:date_full`, and it will output localized dates or times. For additional
+information about localized dates and possible date/time formatting layouts, please see
+[Hugo: time.Format](https://gohugo.io/functions/dateformat/).
+
 ### Thumbnail visibility
 
 By default, a thumbnail image has shown for a list and single pages simultaneously. In some cases, you may want to show

--- a/layouts/partials/post_meta/date.html
+++ b/layouts/partials/post_meta/date.html
@@ -2,11 +2,11 @@
 <div class="meta__item-datetime meta__item">
 	{{ partial "svg/time.svg" (dict "class" "meta__icon") -}}
 	<time class="meta__text" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">
-		{{- .Date.Format (.Site.Params.dateformat | default "January 02, 2006") -}}
+		{{- .Date | dateFormat (.Site.Params.dateformat | default "January 02, 2006") -}}
 	</time>
 	{{- if ne .Date .Lastmod }}
 	<time class="meta__text" datetime="{{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}">(
-		{{- T "meta_lastmod" }}: {{ .Lastmod.Format (.Site.Params.dateformat | default "January 02, 2006") -}}
+		{{- T "meta_lastmod" }}: {{ .Lastmod | dateFormat (.Site.Params.dateformat | default "January 02, 2006") -}}
 	)</time>
 	{{- end -}}
 </div>


### PR DESCRIPTION
This PR added post meta dates localization with `time.Format` function (via `dateFormat` alias). Hugo v0.87.0 or later is required. The default date format is unchanged to preserve compatibility.

---

With [Hugo v0.87.0](https://gohugo.io/news/0.87.0-relnotes/) (or later), `date` meta field shows localized dates (with weekdays and months in the current language) by default. In most cases, such a transition is painless, but owners of multilingual sites should be careful and check that everything translates as expected after the upgrade.

You can also use a predefined layout, like `:date_full`, and it will output localized dates or times. For additional information about localized dates and possible date/time formatting layouts, please see [Hugo: time.Format](https://gohugo.io/functions/dateformat/).

Fixes #318