### PR TITLE
Add TOC widget

### DIFF
--- a/layouts/partials/widgets/toc.html
+++ b/layouts/partials/widgets/toc.html
@@ -1,0 +1,8 @@
+<div class="widget-sidemenu widget">
+	<div class="post__toc toc">
+		<div class="toc__title">{{ T "toc_title" }}</div>
+		<div class="toc__menu">
+			{{ .TableOfContents }}
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
In my setup, I wanted to have a table of content on the sidebar, so I made a widget based on the `post_toc.html`. 
The widget uses the same title.

This might be useful for others.

Using in the example site:

```yaml
sidebar: true
widgets:
  - toc
```
![toc_widget](https://github.com/Vimux/Mainroad/assets/3854784/3144f6e0-9221-4aaa-9471-8f4388c0fea1)
