### PR TITLE
Remove X-UA-Compatible meta tag

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>{{ block "title" . }}{{ if not .IsHome }}{{ .Title }} - {{ end }}{{ .Site.Title }}{{ end }}</title>
 	<script>(function(d,e){d[e]=d[e].replace("no-js","js");})(document.documentElement,"className");</script>
 	<meta name="description" content="{{ if .IsHome }}{{ .Site.Params.description }}{{ else }}{{ .Params.Description }}{{ end }}">


### PR DESCRIPTION
This PR removes the `X-UA-Compatible` meta tag as it is no longer needed. As of IE11, "[document modes are deprecated and should no longer be used](https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/dev-guides/bg182625(v=vs.85)#document-mode-changes)."

Background:
This meta tag is only relevant to the Internet Explorer browser family. IE has different modes for displaying web pages, allowing you to view HTML pages using previous versions of rendering rules. `IE=edge` tells Internet Explorer to use the latest available document mode. However, it is a default mode (IE11) for the HTML5 doctype declaration.