### PR TITLE
Fix deprecation warning

### DIFF
--- a/layouts/partials/authorbox.html
+++ b/layouts/partials/authorbox.html
@@ -1,21 +1,21 @@
 {{- if .Param "authorbox" }}
 <div class="authorbox clearfix">
-	{{- if and (not .Site.Author.avatar) (not .Site.Author.name) (not .Site.Author.bio) }}
+	{{- if and (not .Site.Language.Params.Author.avatar) (not .Site.Language.Params.Author.name) (not .Site.Language.Params.Author.bio) }}
 	<p class="authorbox__warning">
 		<strong>WARNING:</strong> Authorbox is activated, but [Author] parameters are not specified.
 	</p>
 	{{- end }}
-	{{- with .Site.Author.avatar }}
+	{{- with .Site.Language.Params.Author.avatar }}
 	<figure class="authorbox__avatar">
-		<img alt="{{ $.Site.Author.name }} avatar" src="{{ $.Site.Author.avatar | relURL }}" class="avatar" height="90" width="90">
+		<img alt="{{ $.Site.Language.Params.Author.name }} avatar" src="{{ $.Site.Language.Params.Author.avatar | relURL }}" class="avatar" height="90" width="90">
 	</figure>
 	{{- end }}
-	{{- with .Site.Author.name }}
+	{{- with .Site.Language.Params.Author.name }}
 	<div class="authorbox__header">
 		<span class="authorbox__name">{{ T "authorbox_name" (dict "Name" .) }}</span>
 	</div>
 	{{- end }}
-	{{- with .Site.Author.bio }}
+	{{- with .Site.Language.Params.Author.bio }}
 	<div class="authorbox__description">
 		{{ . | markdownify }}
 	</div>

--- a/layouts/partials/post_meta/author.html
+++ b/layouts/partials/post_meta/author.html
@@ -1,6 +1,6 @@
-{{- if .Site.Author.name -}}
+{{- if .Site.Language.Params.Author.name -}}
 <div class="meta__item-author meta__item">
 	{{ partial "svg/author.svg" (dict "class" "meta__icon") -}}
-	<span class="meta__text">{{ .Site.Author.name }}</span>
+	<span class="meta__text">{{ .Site.Language.Params.Author.name }}</span>
 </div>
 {{- end -}}


### PR DESCRIPTION
When previewing the example site with hugo v0.124.1, a warning is shown:

```
WARN  The author key in site configuration is deprecated. Use params.author.name instead.
```

This PR fixes this warning.