### PR TITLE
BREAKING CHANGE: fix Hugo's .Site.IsServer error

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         hugo:
-          - '0.48' # min version
+          - '0.54.0' # min version
           - '0.58.2' # https://github.com/gohugoio/hugoThemes/issues/682
           - '0.59.1' # last major version without goldmark renderer
           - '0.60.1' # first major version with goldmark renderer
@@ -44,6 +44,7 @@ jobs:
           - '0.86.1' # https://github.com/gohugoio/hugo/issues/9150
           - '0.93.3' # https://github.com/gohugoio/hugo/commit/837fdfdf45014e3d5ef3b00b01548b68a4489c5f
           - '0.123.8' # https://github.com/gohugoio/hugo/issues/12080
+          - '0.132.2' # .Site.IsServer deprecation ERROR
           - 'latest'
       fail-fast: true
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ to those feedback, otherwise the PR will be closed after 2-4 weeks of inactivity
 ### Pull Request Contribution Prerequisites
 
 * You have Node & npm installed
-* You have Hugo installed at v0.48.0+
+* You have Hugo installed at v0.54.0+
 * You are familiar with Git
 
 ### Pull Request Process

--- a/exampleSite/content/docs/getting-started.md
+++ b/exampleSite/content/docs/getting-started.md
@@ -22,7 +22,7 @@ with the [Hugo](https://gohugo.io/) static site generator.
 ## Installation
 
 Before installing the **Mainroad** theme, make sure that you've
-[installed **Hugo** (version 0.48 or later)](https://gohugo.io/getting-started/quick-start/#step-1-install-hugo) and
+[installed **Hugo** (version 0.54.0 or later)](https://gohugo.io/getting-started/quick-start/#step-1-install-hugo) and
 [created a new site](https://gohugo.io/getting-started/quick-start/#step-2-create-a-new-site). To learn how to install
 Hugo, visit [Hugo Documentation](https://gohugo.io/getting-started/installing/).
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -35,7 +35,13 @@
 	{{- end }}
 
 	<link rel="shortcut icon" href="{{ "favicon.ico" | relURL }}">
-	{{- if not .Site.IsServer }}
+	{{- $server := "" }}
+	{{- if gt (int (index (split hugo.Version ".") 1)) "120" }}
+		{{ $server = hugo.IsServer }}
+	{{- else }}
+		{{ $server = .Site.IsServer }}
+	{{- end -}}
+	{{- if not $server }}
 		{{ template "_internal/google_analytics.html" . }}
 	{{- end }}
 </head>

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,5 +1,11 @@
-{{ if and .Site.Config.Services.Disqus.Shortname (index .Params "comments" | default "true") (not .Site.IsServer) }}
+{{- $server := "" }}
+{{- if ge (int (index (split hugo.Version ".") 1)) "120" }}
+	{{- $server = hugo.IsServer }}
+{{- else }}
+	{{- $server = .Site.IsServer }}
+{{- end }}
+{{- if and .Site.Config.Services.Disqus.Shortname (index .Params "comments" | default "true") (not $server) }}
 <section class="comments">
 	{{ template "_internal/disqus.html" . }}
 </section>
-{{ end }}
+{{- end }}

--- a/theme.toml
+++ b/theme.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/vimux/mainroad/"
 demosite = "https://mainroad-demo.netlify.app/"
 tags = ["blog", "responsive", "light", "multilingual", "customizable", "widgets", "wordpress"]
 features = ["blog", "responsive", "multilingual", "widgets", "rss", "disqus", "google analytics", "wordpress"]
-min_version = "0.48"
+min_version = "0.54.0"
 
 [author]
   name = "Vimux"


### PR DESCRIPTION
As of Hugo 0.120.0, `.Site.IsServer` is deprecated, and starting with Hugo 0.132.0, it causes a build error. Unfortunately, this is a breaking upstream change that we can't "fix" on our end. As a result, we had to raise the minimum supported version to v0.54.0 and implement another workaround to ensure compatibility with older versions, not just Hugo v0.120.0 and all subsequent versions.

> [!Warning]
> **This change requires manual intervention if you are using the Mainroad theme with older versions of Hugo v0.48 - v0.53. Please upgrade Hugo.**

Changes:

* Fix .Site.IsServer deprecation error
* Raise the minimum supported version to Hugo v0.54.0
* Update documentation
* сi-test.yml: Add 0.132.0 to the cursed list

Unlike Hugo, we avoid breaking our code annually without a compelling reason. Unfortunately, there are more and more such upstream changes.

Fix #369