### PR TITLE
feat: update for new Pagination template action

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ theme = "mainroad"
 baseurl = "/"
 title = "Mainroad"
 languageCode = "en-us"
-paginate = "10" # Number of posts per page
 theme = "mainroad"
 disqusShortname = "" # DEPRECATED! Use .Services.Disqus.Shortname
 googleAnalytics = "" # DEPRECATED! Use .Services.googleAnalytics.ID
+
+[Pagination]
+  pagerSize = 10 # Number of posts per page
 
 [services.disqus]
   shortname = "" # Enable Disqus by entering your Disqus shortname

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,10 +1,12 @@
 baseurl = "/"
 title = "Mainroad"
 languageCode = "en-us"
-paginate = "10" # Number of posts per page
 theme = "mainroad"
 disqusShortname = "" # Enable comments by entering your Disqus shortname
 googleAnalytics = "" # Enable Google Analytics by entering your tracking id
+
+[Pagination]
+  pagerSize = 10 # Number of posts per page
 
 [Author]
   name = "John Doe"


### PR DESCRIPTION
This PR update the theme for avoid the next warn

```
WARN  deprecated: site config key paginate was deprecated in Hugo v0.128.0 and will be removed in a future release. Use pagination.pagerSize instead.
```