### PR TITLE
Update Authorbox to use author data

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,6 @@ googleAnalytics = "" # DEPRECATED! Use .Services.googleAnalytics.ID
 [services.googleAnalytics]
   ID = "" # Enable Google Analytics by entering your tracking ID
 
-[Author] # Used in authorbox
-  name = "John Doe"
-  bio = "John Doe's true identity is unknown. Maybe he is a successful blogger or writer. Nobody knows it."
-  avatar = "img/avatar.png"
-
 [Params]
   description = "John Doe's Personal blog about everything" # Site description. Used in meta description
   copyright = "John Doe" # Footer copyright holder, otherwise will use site title
@@ -158,6 +153,22 @@ googleAnalytics = "" # DEPRECATED! Use .Services.googleAnalytics.ID
 
 For more information about all available standard configuration settings, please read
 [All Hugo Configuration Settings](https://gohugo.io/getting-started/configuration/#all-configuration-settings).
+
+### Authorbox
+
+Create a file at `data/authors/earnestfreeguy.json`. Add the following contents to it:
+
+```json
+{
+  "name": "Earnest Freeguy",
+  "avatar": "img/avatar-earnestfreeguy.png",
+  "bio": "Earnest cares a lot about Liberty. He likes to spend his time blogging, drinking fair-trade coffee, and eating his cats.",
+}
+```
+
+Then make sure to include "author: earnestfreeguy" in the Front Matter for a given post.
+The Authorbox will use `earnestfreeguy` to look up the data entry, then pull the
+various values for that author into the Authorbox.
 
 ### Front Matter example
 

--- a/layouts/partials/authorbox.html
+++ b/layouts/partials/authorbox.html
@@ -1,24 +1,35 @@
 {{- if .Param "authorbox" }}
 <div class="authorbox clearfix">
-	{{- if and (not .Site.Author.avatar) (not .Site.Author.name) (not .Site.Author.bio) }}
-	<p class="authorbox__warning">
-		<strong>WARNING:</strong> Authorbox is activated, but [Author] parameters are not specified.
-	</p>
-	{{- end }}
-	{{- with .Site.Author.avatar }}
-	<figure class="authorbox__avatar">
-		<img alt="{{ $.Site.Author.name }} avatar" src="{{ $.Site.Author.avatar | relURL }}" class="avatar" height="90" width="90">
-	</figure>
-	{{- end }}
-	{{- with .Site.Author.name }}
-	<div class="authorbox__header">
-		<span class="authorbox__name">{{ T "authorbox_name" (dict "Name" .) }}</span>
-	</div>
-	{{- end }}
-	{{- with .Site.Author.bio }}
-	<div class="authorbox__description">
-		{{ . | markdownify }}
-	</div>
+	{{ $author := default .Site.Author (index .Site.Data.authors (.Params.author | default "default")) }}
+	{{- with $author }}
+		{{- if (not $author.avatar) }}
+			<p class="authorbox__warning">
+				<strong>WARNING:</strong> Authorbox is activated, but author is missing the "avatar" property.
+			</p>
+		{{- end }}
+		{{- if (not $author.name) }}
+		<p class="authorbox__warning">
+			<strong>WARNING:</strong> Authorbox is activated, but author is missing the "name" property.
+		if (not $author.bio) }}
+			<p class="authorbox__warning">
+				<strong>WARNING:</strong> Authorbox is activated, but author is missing the "bio" property.
+			</p>
+		{{- end }}
+		{{- with $author.avatar }}
+		<figure class="authorbox__avatar">
+			<img alt="{{ $author.name }} avatar" src="{{ $author.avatar | relURL }}" class="avatar" height="90" width="90">
+		</figure>
+		{{- end }}
+		{{- with $author.name }}
+		<div class="authorbox__header">
+			<span class="authorbox__name">{{ T "authorbox_name" (dict "Name" .) }}</span>
+		</div>
+		{{- end }}
+		{{- with $author.bio }}
+		<div class="authorbox__description">
+			{{ . | markdownify }}
+		</div>
+		{{- end }}
 	{{- end }}
 </div>
 {{- end }}


### PR DESCRIPTION
This supports multiple authors, and avoids using the now-deprecated [Author] block in Hugo.toml

Fixes Issue #382