### PR TITLE
Made the credits in footer optional

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -20,6 +20,7 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
   pager = true
   post_meta = ["date", "categories"] # Order of post meta information
   mainSections = ["post", "docs"]
+  show_credits = true
 
 [Params.logo]
   subtitle = "Just another site" # Logo subtitle

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,7 +3,9 @@
 		{{ partial "footer_links.html" . }}
 		<div class="footer__copyright">
 			&copy; {{ now.Format "2006" }} {{ .Site.Params.copyright | default .Site.Title }}.
+			{{ if .Site.Params.show_credits }}
 			<span class="footer__copyright-credits">{{ T "footer_credits" | safeHTML }}</span>
+			{{ end }}
 		</div>
 	</div>
 </footer>


### PR DESCRIPTION
Regarding my problem with readability (issue #385) I decided to just hide the credits in the footer. I have to admit that this isn't the most beautiful way of reaching a score of 100 in lighthouse again but it is one possibility.

The branch name isn't the best since the footer is still there and just the credit part is gone.

Of course it would be possible to just change the translation text and remove the links as well. But this brings the new "_feature_" of hiding credits which might be desired by some users.