### PR TITLE
`.Site.IsMultiLingual` was deprecated in Hugo v0.124.0

### DIFF
--- a/layouts/partials/authorbox.html
+++ b/layouts/partials/authorbox.html
@@ -1,21 +1,21 @@
 {{- if .Param "authorbox" }}
 <div class="authorbox clearfix">
-	{{- if and (not .Site.Author.avatar) (not .Site.Author.name) (not .Site.Author.bio) }}
+	{{- if and (not .Site.Params.Author.avatar) (not .Site.Params.Author.name) (not .Site.Params.Author.bio) }}
 	<p class="authorbox__warning">
 		<strong>WARNING:</strong> Authorbox is activated, but [Author] parameters are not specified.
 	</p>
 	{{- end }}
-	{{- with .Site.Author.avatar }}
+	{{- with .Site.Params.Author.avatar }}
 	<figure class="authorbox__avatar">
-		<img alt="{{ $.Site.Author.name }} avatar" src="{{ $.Site.Author.avatar | relURL }}" class="avatar" height="90" width="90">
+		<img alt="{{ $.Site.Params.Author.name }} avatar" src="{{ $.Site.Params.Author.avatar | relURL }}" class="avatar" height="90" width="90">
 	</figure>
 	{{- end }}
-	{{- with .Site.Author.name }}
+	{{- with .Site.Params.Author.name }}
 	<div class="authorbox__header">
 		<span class="authorbox__name">{{ T "authorbox_name" (dict "Name" .) }}</span>
 	</div>
 	{{- end }}
-	{{- with .Site.Author.bio }}
+	{{- with .Site.Params.Author.bio }}
 	<div class="authorbox__description">
 		{{ . | markdownify }}
 	</div>

--- a/layouts/partials/post_meta/author.html
+++ b/layouts/partials/post_meta/author.html
@@ -1,6 +1,6 @@
-{{- if .Site.Author.name -}}
+{{- if .Site.Params.Author.name -}}
 <div class="meta__item-author meta__item">
 	{{ partial "svg/author.svg" (dict "class" "meta__icon") -}}
-	<span class="meta__text">{{ .Site.Author.name }}</span>
+	<span class="meta__text">{{ .Site.Params.Author.name }}</span>
 </div>
 {{- end -}}

--- a/layouts/partials/widgets/languages.html
+++ b/layouts/partials/widgets/languages.html
@@ -1,5 +1,5 @@
 {{- $translations := .Site.Home.AllTranslations }}
-{{- if and .Site.IsMultiLingual (gt (len $translations) 0) }}
+{{- if and hugo.IsMultilingual (gt (len $translations) 0) }}
 <div class="widget-languages widget">
 	<h4 class="widget__title">{{ T "languages_title" }}</h4>
 	<div class="widget__content">


### PR DESCRIPTION
`.Site.IsMultiLingual` was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.141.0. `Use hugo.IsMultilingual `