### PR TITLE
feat: allow multiple google fonts links

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ googleAnalytics = "" # DEPRECATED! Use .Services.googleAnalytics.ID
   mathjax = true # Enable MathJax
   mathjaxPath = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js" # Specify MathJax path
   mathjaxConfig = "TeX-AMS-MML_HTMLorMML" # Specify MathJax config
-  googleFontsLink = "https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700" # Load Google Fonts
+  googleFontsLinks = [
+    "https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700" # Load Google Fonts
+  ]
   customCSS = ["css/custom.css"] # Include custom CSS files
   customJS = ["js/custom.js"] # Include custom JS files
 

--- a/exampleSite/content/docs/customization.md
+++ b/exampleSite/content/docs/customization.md
@@ -367,11 +367,11 @@ Our href font link:
     https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,700;1,400&display=swap
     ```
 
-1. Set `googleFontsLink` site's config param value to your href font link. For example:
+1. Set `googleFontsLinks` site's config param value to your href font links. For example:
 
     ```toml
     [Params]
-      googleFontsLink = "https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,700;1,400&display=swap"
+      googleFontsLinks = ["https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,700;1,400&display=swap"]
     ```
 
 1. Override default font-family set(s):

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,12 +16,11 @@
 		{{ template "_internal/twitter_cards.html" . }}
 	{{- end }}
 
-	{{- $googleFontsLinks := .Site.Params.googleFontsLink | default "https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700" }}
+	{{- $googleFontsLinks := .Site.Params.googleFontsLinks | default (slice "https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700") }}
 	{{- if $googleFontsLinks }}
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link rel="dns-prefetch" href="//fonts.googleapis.com">
 	<link rel="dns-prefetch" href="//fonts.gstatic.com">
-
 		{{- range $googleFontsLinks }}
 			{{- if hasPrefix . "https://fonts.googleapis.com/" }}
 	<link rel="stylesheet" {{ printf `href="%s"` . | safeHTMLAttr }}>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,12 +16,17 @@
 		{{ template "_internal/twitter_cards.html" . }}
 	{{- end }}
 
-	{{- $googleFontsLink := .Site.Params.googleFontsLink | default "https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700" }}
-	{{- if hasPrefix $googleFontsLink "https://fonts.googleapis.com/" }}
+	{{- $googleFontsLinks := .Site.Params.googleFontsLink | default "https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700" }}
+	{{- if $googleFontsLinks }}
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link rel="dns-prefetch" href="//fonts.googleapis.com">
 	<link rel="dns-prefetch" href="//fonts.gstatic.com">
-	<link rel="stylesheet" {{ printf `href="%s"` $googleFontsLink | safeHTMLAttr }}>
+
+		{{- range $googleFontsLinks }}
+			{{- if hasPrefix . "https://fonts.googleapis.com/" }}
+	<link rel="stylesheet" {{ printf `href="%s"` . | safeHTMLAttr }}>
+			{{- end }}
+		{{- end }}
 	{{- end }}
 
 	{{ $style := resources.Get "css/style.css" | resources.ExecuteAsTemplate "css/style.css" . -}}


### PR DESCRIPTION
Allow for loading multiple `googleFontLinks` by declaring it as an array and ranging over it in `baseof.html`